### PR TITLE
Satisfy Istio's requirement for named ports  and update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,3 @@
-default_stages:
-  - push
 repos:
   - repo: https://github.com/norwoodj/helm-docs
     rev: v1.11.0
@@ -8,13 +6,13 @@ repos:
         name: 'Helm Docs for XP Management Service Chart'
         files: '^infra/charts/management-service/'
         args:
-          - --chart-search-root='infra/charts/management-service'
+          - --chart-search-root=infra/charts/management-service
           - --template-files=./README.md.gotmpl
       - id: helm-docs-built
         name: 'Helm Docs for XP Treatment Service Chart'
         files: '^infra/charts/treatment-service/'
         args:
-          - --chart-search-root='infra/charts/treatment-service'
+          - --chart-search-root=infra/charts/treatment-service
           - --template-files=./README.md.gotmpl
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ repos:
         name: 'Helm Docs for XP Management Service Chart'
         files: '^infra/charts/management-service/'
         args:
-          - --chart-search-root=infra/charts/management-service
+          - --chart-search-root='infra/charts/management-service'
           - --template-files=./README.md.gotmpl
       - id: helm-docs-built
         name: 'Helm Docs for XP Treatment Service Chart'
         files: '^infra/charts/treatment-service/'
         args:
-          - --chart-search-root=infra/charts/treatment-service
+          - --chart-search-root='infra/charts/treatment-service'
           - --template-files=./README.md.gotmpl
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,21 @@
 default_stages:
   - push
 repos:
+  - repo: https://github.com/norwoodj/helm-docs
+    rev: v1.11.0
+    hooks:
+      - id: helm-docs-built
+        name: 'Helm Docs for XP Management Service Chart'
+        files: '^infra/charts/management-service/'
+        args:
+          - --chart-search-root=infra/charts/management-service
+          - --template-files=./README.md.gotmpl
+      - id: helm-docs-built
+        name: 'Helm Docs for XP Treatment Service Chart'
+        files: '^infra/charts/treatment-service/'
+        args:
+          - --chart-search-root=infra/charts/treatment-service
+          - --template-files=./README.md.gotmpl
   - repo: local
     hooks:
       - id: format
@@ -15,3 +30,11 @@ repos:
         language: system
         entry: make lint
         pass_filenames: false
+  - repo: local
+    hooks:
+      - id: prettier
+        name: 'Prettier for UI'
+        files: '^ui/'
+        types_or: [javascript, css]
+        language: system
+        entry: bash -c 'cd ui && yarn lint'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,11 +56,14 @@ Setup [`pre-commit`](https://pre-commit.com/) to automatically lint and format t
 2. Install `pre-commit` with `pip` &amp; install pre-push hooks
 
     ```sh
-    pip install pre-commit
-    pre-commit install --hook-type pre-commit --hook-type pre-push
+    # Clear existing hooks    
+    git config --unset-all core.hooksPath
+    rm -rf .git/hooks
+    # Install hooks
+    make setup
     ```
 
-3. On push, the pre-commit hook will run. This runs `make format` and `make lint`.
+3. On push, the pre-commit hook will run. This runs `make format`, `make lint`, `UI linting` and `generation of helm docs`.
 
 ## XP Management/Treatment Service using Go
 

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,11 @@ setup:
 	@echo "> Initializing dependencies ..."
 	@test -x ${GOPATH}/bin/golangci-lint || go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.40.1
 
+	@echo "Setting up dev tools..."
+	@test -x "$(which pre-commit)" || pip install pre-commit
+	@pre-commit install
+	@pre-commit install-hooks
+
 tidy-management-service:
 	cd ${MANAGEMENT_SVC_PATH} && go mod tidy
 

--- a/README.md
+++ b/README.md
@@ -75,4 +75,4 @@ replace github.com/gojek/xp/treatment-service => github.com/gojek/turing-experim
 
 XP is still under active development. Please have a look at our contributing and development guides if you want to contribute to the project:
 
-- [Contribution Process for XP](https://github.com/gojek/xp/blob/main/CONTRIBUTING.md)
+- [Contribution Process for XP](https://github.com/caraml-dev/turing-experiments/blob/main/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -75,4 +75,4 @@ replace github.com/gojek/xp/treatment-service => github.com/gojek/turing-experim
 
 XP is still under active development. Please have a look at our contributing and development guides if you want to contribute to the project:
 
-- [Contribution Process for XP](https://github.com/caraml-dev/turing-experiments/blob/main/CONTRIBUTING.md)
+- [Contribution Process for XP](https://github.com/caraml-dev/xp/blob/main/CONTRIBUTING.md)

--- a/infra/charts/management-service/Chart.yaml
+++ b/infra/charts/management-service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.7.0
 description: A Helm chart for Kubernetes Deployment of the XP Management Service
 name: xp-management
-version: 0.1.3
+version: 0.1.2

--- a/infra/charts/management-service/Chart.yaml
+++ b/infra/charts/management-service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.7.0
 description: A Helm chart for Kubernetes Deployment of the XP Management Service
 name: xp-management
-version: 0.1.2
+version: 0.1.3

--- a/infra/charts/management-service/Chart.yaml
+++ b/infra/charts/management-service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.7.0
 description: A Helm chart for Kubernetes Deployment of the XP Managment Service
 name: xp-management
-version: 0.1.1
+version: 0.1.2

--- a/infra/charts/management-service/Chart.yaml
+++ b/infra/charts/management-service/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 appVersion: v0.7.0
-description: A Helm chart for Kubernetes Deployment of the XP Managment Service
+description: A Helm chart for Kubernetes Deployment of the XP Management Service
 name: xp-management
 version: 0.1.2

--- a/infra/charts/management-service/Chart.yaml
+++ b/infra/charts/management-service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.7.0
 description: A Helm chart for Kubernetes Deployment of the XP Managment Service
 name: xp-management
-version: 0.1.2
+version: 0.1.1

--- a/infra/charts/management-service/README.md
+++ b/infra/charts/management-service/README.md
@@ -1,10 +1,10 @@
 # xp-management
 
 ---
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square)
 ![AppVersion: v0.7.0](https://img.shields.io/badge/AppVersion-v0.7.0-informational?style=flat-square)
 
-A Helm chart for Kubernetes Deployment of the XP Managment Service
+A Helm chart for Kubernetes Deployment of the XP Management Service
 
 ## Introduction
 

--- a/infra/charts/management-service/templates/service-swagger.yaml
+++ b/infra/charts/management-service/templates/service-swagger.yaml
@@ -14,7 +14,8 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - port: {{ .Values.swaggerUi.service.externalPort }}
+    - name: http
+      port: {{ .Values.swaggerUi.service.externalPort }}
       targetPort: {{ .Values.swaggerUi.service.internalPort }}
       protocol: TCP
   selector:

--- a/infra/charts/management-service/templates/service-xp.yaml
+++ b/infra/charts/management-service/templates/service-xp.yaml
@@ -14,7 +14,8 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - port: {{ .Values.xpManagement.service.externalPort }}
+    - name: http
+      port: {{ .Values.xpManagement.service.externalPort }}
       targetPort: {{ .Values.xpManagement.service.internalPort }}
       protocol: TCP
   selector:

--- a/infra/charts/treatment-service/Chart.yaml
+++ b/infra/charts/treatment-service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.7.0
 name: xp-treatment
 description: A Helm chart for Kubernetes Deployment of the XP Treatment Service
-version: 0.1.2
+version: 0.1.1

--- a/infra/charts/treatment-service/Chart.yaml
+++ b/infra/charts/treatment-service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: v0.7.0
 name: xp-treatment
 description: A Helm chart for Kubernetes Deployment of the XP Treatment Service
-version: 0.1.1
+version: 0.1.2

--- a/infra/charts/treatment-service/README.md
+++ b/infra/charts/treatment-service/README.md
@@ -1,7 +1,7 @@
 # xp-treatment
 
 ---
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square)
 ![AppVersion: v0.7.0](https://img.shields.io/badge/AppVersion-v0.7.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes Deployment of the XP Treatment Service

--- a/infra/charts/treatment-service/templates/service-swagger.yaml
+++ b/infra/charts/treatment-service/templates/service-swagger.yaml
@@ -15,7 +15,8 @@ metadata:
 spec:
   type: {{ .Values.swaggerUi.service.type }}
   ports:
-    - port: {{ .Values.swaggerUi.service.externalPort }}
+    - name: http
+      port: {{ .Values.swaggerUi.service.externalPort }}
       targetPort: {{ .Values.swaggerUi.service.internalPort }}
       protocol: TCP
   selector:

--- a/infra/charts/treatment-service/templates/service-xp.yaml
+++ b/infra/charts/treatment-service/templates/service-xp.yaml
@@ -14,7 +14,8 @@ metadata:
 spec:
   type: {{ .Values.xpTreatment.service.type }}
   ports:
-    - port: {{ .Values.xpTreatment.service.externalPort }}
+    - name: http
+      port: {{ .Values.xpTreatment.service.externalPort }}
       targetPort: {{ .Values.xpTreatment.service.internalPort }}
       protocol: TCP
   selector:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/gojek/xp/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/gojek/xp/blob/master/CONTRIBUTING.md#unit-tests
3. Make sure documentation is updated for your PR

-->

**What this PR does / why we need it**:
Istio [requires](https://istio.io/v1.0/docs/setup/kubernetes/spec-requirements/) service ports to be named in order to work correctly with the routing features. (It is also explained here in detail: [Protocol Selection](https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/)). While the current chart works correctly with some basic usage of Istio (i.e. exposing a service via VirtualService), it fails to work as expected inside Istio's Service mesh.

This MR adds http name to XP's Services and bumps up a patch version of the chart, similar to how Turing's helm chart has been [updated](https://github.com/caraml-dev/turing/pull/223).

In addition, the [pre-commit](https://pre-commit.com/#intro) tool has been integrated which helps automate some additional checks / actions when some files are being modified (eg: regenerating the Helm docs with changes to the chart values). The  `.pre-commit-config.yaml` file has each of these hooks:
* Helm docs generation
* Linting of Golang, JS code (local hook, using the respective `make` target)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
`NONE`
