### PR TITLE
Add CaraML docs sync workflow

### DIFF
--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -1,0 +1,22 @@
+# This workflow triggers sync of docs to caraml-dev/docs
+
+name: Trigger CaraML Docs Sync
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  trigger-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Remote Doc Sync Workflow
+        uses: caraml-dev/docs/.github/actions/trigger-remote-docs-sync@main
+        with:
+          module: 'experiment'
+          git_https: 'https://github.com/caraml-dev/turing-experiments.git'
+          doc_folder: 'docs'
+          ref_name: ${{ github.ref_name }}
+          ref_type: ${{ github.ref_type }}
+          credentials: ${{ secrets.CARAML_SYNC }}

--- a/.github/workflows/trigger-caraml-doc-sync.yml
+++ b/.github/workflows/trigger-caraml-doc-sync.yml
@@ -15,7 +15,7 @@ jobs:
         uses: caraml-dev/docs/.github/actions/trigger-remote-docs-sync@main
         with:
           module: 'experiment'
-          git_https: 'https://github.com/caraml-dev/turing-experiments.git'
+          git_https: 'https://github.com/caraml-dev/xp.git'
           doc_folder: 'docs'
           ref_name: ${{ github.ref_name }}
           ref_type: ${{ github.ref_type }}

--- a/README.md
+++ b/README.md
@@ -62,14 +62,7 @@ To test authorization for Management Service locally, make the following changes
 
 #### c. Using XP
 
-To use the XP Go modules as API dependencies, `replace` directives need to be used when consuming both the Management and Treatment API modules since the API modules uses local relative path.
-
-```go
-replace github.com/caraml-dev/xp/clients => github.com/caraml-dev/xp/clients v0.0.0
-replace github.com/caraml-dev/xp/common => github.com/caraml-dev/xp/common v0.0.0
-replace github.com/caraml-dev/xp/management-service => github.com/caraml-dev/xp/management-service v0.0.0
-replace github.com/caraml-dev/xp/treatment-service => github.com/caraml-dev/xp/treatment-service v0.0.0
-```
+To use the XP Go modules as API dependencies, simply import the XP Go modules directly i.e. `import "github.com/caraml-dev/xp/..."`
 
 ## Contributing
 


### PR DESCRIPTION
**What this PR does / why we need it**:
With the migration of `turing-experiments` to the CaraML organisation, we are syncing the docs from `turing-experiments` automatically to https://github.com/caraml-dev/docs. 

This PR introduces an additional workflow which performs this step, which can be found here: https://github.com/caraml-dev/docs/tree/main/.github/actions/trigger-remote-docs-sync

**Which issue(s) this PR fixes**:
None
