### PR TITLE
Bugfix: Cater to optional segmenter matches in filterByLookupOrder

### DIFF
--- a/treatment-service/services/experiment_service.go
+++ b/treatment-service/services/experiment_service.go
@@ -124,7 +124,6 @@ func (es *experimentService) filterByLookupOrder(
 	segmenters []string,
 	segmenterTypes map[string]schema.SegmenterType,
 ) []*models.ExperimentMatch {
-	// Stop search when we have at least 1 match
 	filtered := matches
 	for _, segmenter := range segmenters {
 		orderedValues := filters[segmenter]
@@ -155,7 +154,8 @@ func (es *experimentService) filterByLookupOrder(
 				}
 			}
 		}
-		// currentFilteredList could be 0 in case of weak matches
+		// currentFilteredList could be 0 in case of weak matches, where the segmenter info was
+		// missing in the original request (i.e., where orderedValues is empty for a given segmenter).
 		if len(currentFilteredList) > 0 {
 			filtered = currentFilteredList
 		}

--- a/treatment-service/services/experiment_service.go
+++ b/treatment-service/services/experiment_service.go
@@ -128,38 +128,37 @@ func (es *experimentService) filterByLookupOrder(
 	filtered := matches
 	for _, segmenter := range segmenters {
 		orderedValues := filters[segmenter]
-		if len(orderedValues) == 1 {
-			continue
-		}
-
 		currentFilteredList := []*models.ExperimentMatch{}
 		segmenterType := segmenterTypes[segmenter]
 		for _, transformedValue := range orderedValues {
 			if len(currentFilteredList) == 0 {
-				for _, segmenterMatch := range filtered {
-					segmenterMatchedValue := segmenterMatch.SegmenterMatches[segmenter]
+				for _, experiment := range filtered {
+					segmenterMatchedValue := experiment.SegmenterMatches[segmenter]
 					switch segmenterType {
 					case "string":
 						if transformedValue.GetString_() == segmenterMatchedValue.Value.GetString_() {
-							currentFilteredList = append(currentFilteredList, segmenterMatch)
+							currentFilteredList = append(currentFilteredList, experiment)
 						}
 					case "integer":
 						if transformedValue.GetInteger() == segmenterMatchedValue.Value.GetInteger() {
-							currentFilteredList = append(currentFilteredList, segmenterMatch)
+							currentFilteredList = append(currentFilteredList, experiment)
 						}
 					case "real":
 						if transformedValue.GetReal() == segmenterMatchedValue.Value.GetReal() {
-							currentFilteredList = append(currentFilteredList, segmenterMatch)
+							currentFilteredList = append(currentFilteredList, experiment)
 						}
 					case "bool":
 						if transformedValue.GetBool() == segmenterMatchedValue.Value.GetBool() {
-							currentFilteredList = append(currentFilteredList, segmenterMatch)
+							currentFilteredList = append(currentFilteredList, experiment)
 						}
 					}
 				}
 			}
 		}
-		filtered = currentFilteredList
+		// currentFilteredList could be 0 in case of weak matches
+		if len(currentFilteredList) > 0 {
+			filtered = currentFilteredList
+		}
 	}
 
 	return filtered

--- a/treatment-service/services/experiment_service_test.go
+++ b/treatment-service/services/experiment_service_test.go
@@ -256,6 +256,12 @@ func (s *ExperimentServiceTestSuite) TestGetExperiment() {
 			expLookupFilters: makeExperimentLookupFilters(s2.CellID(3592210809859604480), 1, 20, "seg-1", 1, 9001, false),
 			expResponse:      s.LocalStorage.Experiments[5][0].Experiment,
 		},
+		"resolve tiers | no experiment variables": {
+			projectId:        5,
+			reqFilter:        map[string][]*_segmenters.SegmenterValue{},
+			expLookupFilters: makeExperimentLookupFilters(s2.CellID(3592210809859604480), 1, 20, "seg-1", 1, 9001, false),
+			expResponse:      s.LocalStorage.Experiments[5][0].Experiment,
+		},
 		"resolve all hierarchy | optional segmenter": {
 			projectId:        6,
 			reqFilter:        makeRequestFilter(s2.CellID(3592210809859604480), 1, 20, "seg-1", 1, 9001, false),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/caraml-dev/xp/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/caraml-dev/xp/blob/master/CONTRIBUTING.md#unit-tests
3. Make sure documentation is updated for your PR

-->

**What this PR does / why we need it**:
When multiple experiments are matched by the Fetch Treatment API, the hierarchical experiment filters ensure that ultimately, only one experiment will be selected. However, in a case where there are multiple experiments after `filterByMatchStrength` and there are missing segmenter values to the Fetch Treatment request, the `filterByLookupOrder` function would simply eliminate the experiment(s) from the matches. But, in fact, the overall matches should only be updated if there are non-zero matches for a given segmenter value (which will automatically handle `nil` segmenter values).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This PR addresses the issue above by only updating the filtered experiments if the matches in the current iteration is non-zero, much like the other filters for hierarchical experiments.
