### PR TITLE
Addition of text wrapping style to route selection panel 

### DIFF
--- a/ui/src/turing/components/configuration/experiments_config/ExperimentsConfigGroup.scss
+++ b/ui/src/turing/components/configuration/experiments_config/ExperimentsConfigGroup.scss
@@ -6,6 +6,7 @@
 
     .euiDescriptionList__description {
       width: calc(100% - 150px);
+      white-space: normal !important;
     }
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces a tiny fix to the UI to allow the entire route name path of a standard ensembler to be displayed, instead of being truncated.

It involves adding an additional css style property to the existing `experimentSummaryPanel` class to allow text wrapping.

**Before:**
![Screenshot 2022-09-27 at 4 27 32 PM](https://user-images.githubusercontent.com/36802364/192475155-4cf68edb-5c36-4b49-96b1-a66f83901fe1.png)

**After:**
![Screenshot 2022-09-27 at 4 27 13 PM](https://user-images.githubusercontent.com/36802364/192475193-dde7e507-dd70-414c-9a1c-7346929f1ec4.png)

