### PR TITLE
VariablesConfigGroup UI Bugfix / doc update

### DIFF
--- a/docs/how-to/06_modifying_experiments.md
+++ b/docs/how-to/06_modifying_experiments.md
@@ -25,7 +25,7 @@ Experiments can be created in the 'active' state and disabled later on, or vice 
 
 ## Experiment History
 
-When an experiment is edited or its status is changed, the existing details in the experiment prior to the edit would be saved as a historical version and can be viewed from the **History** tab in the Experiment Details view.
+When an experiment is edited, the existing details in the experiment prior to the edit would be saved as a historical version and can be viewed from the **History** tab in the Experiment Details view. Note that status changes via the Activate / Deactivate action would still create a historical version but would not increment the version number.
 
 ## Deleting Experiments
 

--- a/ui/src/turing/components/configuration/variables_config/VariablesConfigGroup.js
+++ b/ui/src/turing/components/configuration/variables_config/VariablesConfigGroup.js
@@ -20,7 +20,7 @@ export const VariablesConfigGroup = ({ variables }) => {
       width: "35%",
       render: (value) => (
         <EuiTitle size="xxs">
-          <EuiTextColor>{value}</EuiTextColor>
+          <EuiTextColor>{value || "-"}</EuiTextColor>
         </EuiTitle>
       ),
     },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/caraml-dev/xp/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/caraml-dev/xp/blob/master/CONTRIBUTING.md#unit-tests
3. Make sure documentation is updated for your PR

-->

**What this PR does / why we need it**: This PR adds a small UI bugfix to the remote component meant for Turing router details view, to indicate a `-` where the variable's field has not been set. A small update is also made to the user docs to clarify the experiment versioning behavior.