### PR TITLE
Bugfix: Navigation with react-router-dom

### DIFF
--- a/ui/src/AppRoutes.js
+++ b/ui/src/AppRoutes.js
@@ -7,13 +7,19 @@ import Home from "Home";
 
 const App = () => {
   const { appConfig } = useConfig();
+
   return (
     <Routes>
-      <Route path={appConfig.homepage} />
-      <Route index element={<Home />} />
-      <Route path="projects/:projectId">
-        <Route index element={<Navigate to="experiments" replace={true} />} />
-        <Route path="experiments/*" element={<ExperimentsLandingPage />} />
+      {/* We need this redirection because XP is not a recognized MLP app and so PrivateLayout 
+      should not redirect to /xp directly on project change. */}
+      <Route path="projects/:projectId/*" element={<Navigate to={appConfig.homepage} replace={true} />} />
+      {/* ALL ROUTES */}
+      <Route path={appConfig.homepage}>
+        <Route index element={<Home />} />
+        <Route path="projects/:projectId">
+          <Route index element={<Navigate to="experiments" replace={true} />} />
+          <Route path="experiments/*" element={<ExperimentsLandingPage />} />
+        </Route>
       </Route>
       {/* DEFAULT */}
       <Route path="*" element={<Navigate to="/pages/404" replace={true} />} />

--- a/ui/src/Home.js
+++ b/ui/src/Home.js
@@ -1,13 +1,14 @@
-import React, { Fragment } from "react";
-
+import React, { Fragment, useContext } from "react";
 import { EuiPageTemplate } from "@elastic/eui";
-
+import { ProjectsContext } from "@gojek/mlp-ui";
+import { Navigate } from "react-router-dom";
 import { useConfig } from "config";
 
 const Home = () => {
   const { appConfig } = useConfig();
+  const { currentProject } = useContext(ProjectsContext);
 
-  return (
+  return !currentProject ? (
     <EuiPageTemplate>
       <EuiPageTemplate.EmptyPrompt
         iconType={appConfig.appIcon}
@@ -19,6 +20,8 @@ const Home = () => {
         }
       />
     </EuiPageTemplate>
+  ) : (
+    <Navigate to={`projects/${currentProject.id}`} replace={true} />
   );
 };
 

--- a/ui/src/PrivateLayout.js
+++ b/ui/src/PrivateLayout.js
@@ -24,7 +24,6 @@ export const PrivateLayout = () => {
           <ApplicationsContext.Consumer>
             {() => (
               <Header
-                homepage={appConfig.homepage}
                 onProjectSelect={pId =>
                   navigate(urlJoin("projects", pId))
                 }

--- a/ui/src/PrivateLayout.js
+++ b/ui/src/PrivateLayout.js
@@ -22,14 +22,15 @@ export const PrivateLayout = () => {
       <ApplicationsContextProvider>
         <ProjectsContextProvider>
           <ApplicationsContext.Consumer>
-            {({ currentApp }) => (
+            {() => (
               <Header
                 homepage={appConfig.homepage}
                 onProjectSelect={pId =>
-                  navigate(urlJoin(currentApp?.href, "projects", pId, "experiments"))
+                  navigate(urlJoin("projects", pId))
                 }
                 docLinks={appConfig.docsUrl}
-              />)}
+              />
+            )}
           </ApplicationsContext.Consumer>
           <Outlet />
         </ProjectsContextProvider>

--- a/ui/src/experiments/ExperimentsLandingPage.js
+++ b/ui/src/experiments/ExperimentsLandingPage.js
@@ -68,7 +68,7 @@ const ExperimentsLandingPage = () => {
         which results in incorrect /experiments/experiments prefix.
          */}
           <Route
-            path="experiments"
+            path="experiments/*"
             element={<Navigate to={location.pathname.replace("/experiments/experiments", "/experiments")}
               replace={true} />} />
         </Routes>

--- a/ui/src/experiments/list/ListExperimentsTable.js
+++ b/ui/src/experiments/list/ListExperimentsTable.js
@@ -1,6 +1,8 @@
 import React from "react";
 
 import { EuiHealth, EuiLink, EuiText } from "@elastic/eui";
+import { useLocation } from "react-router-dom";
+import urlJoin from "proper-url-join";
 
 import { useConfig } from "config";
 import { BasicTable } from "components/table/BasicTable";
@@ -17,6 +19,7 @@ const ListExperimentsTable = ({
   onRowClick,
 }) => {
   const { appConfig } = useConfig();
+  const location = useLocation();
   const tableColumns = [
     {
       field: "id",
@@ -88,11 +91,12 @@ const ListExperimentsTable = ({
       width: "5%",
       render: (item) => {
         return (
+          // We need to do urlJoin to correctly handle trailing slash when used as a remote component
           <EuiLink
             onClick={(e) => {
               e.stopPropagation();
             }}
-            href={item.id}
+            href={urlJoin(location.pathname, item.id)}
             target="_blank"
           />
         );


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/caraml-dev/xp/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/caraml-dev/xp/blob/master/CONTRIBUTING.md#unit-tests
3. Make sure documentation is updated for your PR

-->

**What this PR does / why we need it**: This PR is a follow up from https://github.com/caraml-dev/xp/pull/45 which addresses the navigation regressions introduced by that PR.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes the following issues:
* `ui/src/PrivateLayout.js`, `ui/src/AppRoutes.js` - When the XP app is accessed standalone (primarily during local development), the header bar's project change dropdown was not updating the UI states properly. This is because XP is not a valid first-level MLP app and therefore, `currentApp` would be undefined and cannot be used in `onProjectSelect` as with other apps like Turing. Directly navigating to `/xp` via `onProjectSelect` handler also results in incorrect states because of the underlying implementation of the [ProjectsContext](https://github.com/gojek/mlp/blob/main/ui/packages/lib/src/providers/project/context.js#L39) which requires the path to begin with `currentApp.href`. So, this is now handled by redirecting to `/projects/{pId}` (`currentApp.href` = "/") on project change which will subsequently redirect to `/xp` and then `/xp/projects/{pId}/experiments` via other redirects in `AppRoutes`.
* `ui/src/PrivateLayout.js` - Header's homepage should be empty (default "/") so that in the multi-app deployment, clicking the header logo can take us to the MLP landing page.
* `ui/src/experiments/ExperimentsLandingPage.js` - Fixed missing `/*` pattern to match nested routes
* `ui/src/experiments/list/ListExperimentsTable.js` - Some differences in handling of trailing slash between react router v5 and v6 require special handling for the Link navigation.
