### PR TITLE
add protocol for prediction_context display

### DIFF
--- a/ui/src/turing/components/configuration/ExperimentEngineConfigDetails.js
+++ b/ui/src/turing/components/configuration/ExperimentEngineConfigDetails.js
@@ -8,7 +8,7 @@ import { ConfigProvider } from "config";
 import { ExperimentsConfigGroup } from "./experiments_config/ExperimentsConfigGroup";
 import { VariablesConfigGroup } from "./variables_config/VariablesConfigGroup";
 
-const ExperimentEngineConfigDetails = ({ projectId, config }) => (
+const ExperimentEngineConfigDetails = ({ projectId, protocol, config }) => (
   <ConfigProvider>
     <EuiFlexGroup direction="row" wrap>
       <EuiFlexItem grow={1} className="euiFlexItem--smallPanel">
@@ -20,8 +20,12 @@ const ExperimentEngineConfigDetails = ({ projectId, config }) => (
       <EuiFlexItem grow={2} className="euiFlexItem--smallPanel">
         <ConfigSectionPanel
           title="Variables"
-          className="experimentVariablesPanel">
-          <VariablesConfigGroup variables={config.variables} />
+          className="experimentVariablesPanel"
+        >
+          <VariablesConfigGroup
+            variables={config.variables}
+            protocol={protocol}
+          />
         </ConfigSectionPanel>
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/ui/src/turing/components/configuration/variables_config/VariablesConfigGroup.js
+++ b/ui/src/turing/components/configuration/variables_config/VariablesConfigGroup.js
@@ -1,8 +1,10 @@
 import React from "react";
 
-import { EuiBasicTable, EuiTextColor, EuiTitle } from "@elastic/eui";
+import { EuiBasicTable, EuiText, EuiTextColor, EuiTitle } from "@elastic/eui";
 
-export const VariablesConfigGroup = ({ variables }) => {
+import { mapProtocolLabel } from "turing/components/utils/helper";
+
+export const VariablesConfigGroup = ({ variables, protocol }) => {
   const columns = [
     {
       field: "name",
@@ -28,6 +30,9 @@ export const VariablesConfigGroup = ({ variables }) => {
       field: "field_source",
       name: "Source",
       width: "30%",
+      render: (value) => (
+        <EuiText size="s">{mapProtocolLabel(protocol, value)}</EuiText>
+      ),
     },
   ];
 

--- a/ui/src/turing/components/form/EditExperimentEngineConfig.js
+++ b/ui/src/turing/components/form/EditExperimentEngineConfig.js
@@ -14,6 +14,7 @@ import { VariablesConfigPanel } from "./variables_config/VariablesConfigPanel";
 
 const EditExperimentEngineConfigComponent = ({
   projectId,
+  protocol,
   config = {},
   onChangeHandler,
   errors = {},
@@ -41,6 +42,7 @@ const EditExperimentEngineConfigComponent = ({
             <VariablesConfigPanel
               projectId={projectId}
               variables={config.variables}
+              protocol={protocol}
               onChangeHandler={onChange("variables")}
               errors={get(errors, "variables")}
             />
@@ -50,7 +52,8 @@ const EditExperimentEngineConfigComponent = ({
             <EuiCallOut
               title="Project not onboarded to Experiments"
               color="danger"
-              iconType="alert">
+              iconType="alert"
+            >
               <p>
                 {
                   "Please complete onboarding to Turing experiments to configure the router."

--- a/ui/src/turing/components/form/EditStandardEnsemblerConfig.js
+++ b/ui/src/turing/components/form/EditStandardEnsemblerConfig.js
@@ -1,12 +1,20 @@
 import React, { useContext, useRef } from "react";
 
-import { EuiCallOut, EuiFlexItem, EuiLoadingChart, EuiHorizontalRule } from "@elastic/eui";
+import {
+  EuiCallOut,
+  EuiFlexItem,
+  EuiHorizontalRule,
+  EuiLoadingChart,
+} from "@elastic/eui";
 import { OverlayMask } from "@gojek/mlp-ui";
 
 import { Panel } from "components/panel/Panel";
 import { ConfigProvider, useConfig } from "config";
-import ProjectContext, { ProjectContextProvider } from "providers/project/context";
 import { ExperimentContextProvider } from "providers/experiment/context";
+import ProjectContext, {
+  ProjectContextProvider,
+} from "providers/project/context";
+
 import { LinkedRoutesTable } from "./standard_ensembler/LinkedRoutesTable";
 import { RouteNamePathRow } from "./standard_ensembler/RouteNamePathRow";
 
@@ -17,7 +25,9 @@ const EditStandardEnsemblerConfigComponent = ({
   onChange,
   errors,
 }) => {
-  const { appConfig: { routeNamePathPrefix } } = useConfig();
+  const {
+    appConfig: { routeNamePathPrefix },
+  } = useConfig();
 
   const { isProjectOnboarded, isLoaded } = useContext(ProjectContext);
   const overlayRef = useRef();
@@ -40,7 +50,9 @@ const EditStandardEnsemblerConfigComponent = ({
               <LinkedRoutesTable
                 projectId={projectId}
                 routes={routes}
-                treatmentConfigRouteNamePath={routeNamePath.slice(routeNamePathPrefix.length)}
+                treatmentConfigRouteNamePath={routeNamePath.slice(
+                  routeNamePathPrefix.length
+                )}
               />
             </ExperimentContextProvider>
           </Panel>
@@ -49,9 +61,12 @@ const EditStandardEnsemblerConfigComponent = ({
             <EuiCallOut
               title={"Project not onboarded to Experiments"}
               color={"danger"}
-              iconType={"alert"}>
+              iconType={"alert"}
+            >
               <p>
-                {"Please complete onboarding to Turing experiments to configure the standard ensembler."}
+                {
+                  "Please complete onboarding to Turing experiments to configure the standard ensembler."
+                }
               </p>
             </EuiCallOut>
           </Panel>
@@ -74,7 +89,7 @@ const EditStandardEnsemblerConfig = (props) => {
         <EditStandardEnsemblerConfigComponent {...props} />
       </ProjectContextProvider>
     </ConfigProvider>
-  )
+  );
 };
 
 export default EditStandardEnsemblerConfig;

--- a/ui/src/turing/components/form/standard_ensembler/LinkedExperimentsContextMenu.js
+++ b/ui/src/turing/components/form/standard_ensembler/LinkedExperimentsContextMenu.js
@@ -1,18 +1,18 @@
 import React from "react";
 
 import {
-  EuiContextMenu,
-  EuiPopover,
   EuiButtonEmpty,
+  EuiContextMenu,
+  EuiIcon,
   EuiLink,
-  EuiIcon
+  EuiPopover,
 } from "@elastic/eui";
 import { useToggle } from "@gojek/mlp-ui";
 
 export const LinkedExperimentsContextMenu = ({
   projectId,
   linkedExperiments,
-  experimentStatus
+  experimentStatus,
 }) => {
   const [isPopoverOpen, togglePopover] = useToggle();
 
@@ -41,27 +41,31 @@ export const LinkedExperimentsContextMenu = ({
     >
       <EuiContextMenu
         initialPanelId={0}
-        panels={
-          [
-            {
-              id: 0,
-              title: `Linked ${experimentStatus[0].toUpperCase() + experimentStatus.slice(1)} Experiments`,
-              items: Object.values(linkedExperiments[experimentStatus]).map(e => (
-                {
-                  name: (
-                    <EuiLink href={`/turing/projects/${projectId}/experiments/${e.id}/details`} external={false} target={"_blank"}>
-                      {e.name}
-                    </EuiLink>
-                  ),
-                  icon: <EuiIcon type={"popout"} size={"m"} color={"primary"} />,
-                  size: "s",
-                  toolTipContent: "Open experiment details page",
-                  toolTipPosition: "right",
-                }
-              ))
-            }
-          ]
-        }
+        panels={[
+          {
+            id: 0,
+            title: `Linked ${
+              experimentStatus[0].toUpperCase() + experimentStatus.slice(1)
+            } Experiments`,
+            items: Object.values(linkedExperiments[experimentStatus]).map(
+              (e) => ({
+                name: (
+                  <EuiLink
+                    href={`/turing/projects/${projectId}/experiments/${e.id}/details`}
+                    external={false}
+                    target={"_blank"}
+                  >
+                    {e.name}
+                  </EuiLink>
+                ),
+                icon: <EuiIcon type={"popout"} size={"m"} color={"primary"} />,
+                size: "s",
+                toolTipContent: "Open experiment details page",
+                toolTipPosition: "right",
+              })
+            ),
+          },
+        ]}
       />
     </EuiPopover>
   );

--- a/ui/src/turing/components/form/standard_ensembler/LinkedRoutesTable.js
+++ b/ui/src/turing/components/form/standard_ensembler/LinkedRoutesTable.js
@@ -2,56 +2,83 @@ import React, { useContext, useEffect, useState } from "react";
 
 import {
   EuiFlexItem,
+  EuiIcon,
+  EuiInMemoryTable,
   EuiLoadingChart,
   EuiTextAlign,
-  EuiInMemoryTable,
-  EuiIcon,
   EuiTextColor,
 } from "@elastic/eui";
 
-import { getExperimentStatus } from "services/experiment/ExperimentStatus";
-import { LinkedExperimentsContextMenu } from "./LinkedExperimentsContextMenu";
 import ExperimentContext from "providers/experiment/context";
+import { getExperimentStatus } from "services/experiment/ExperimentStatus";
+
+import { LinkedExperimentsContextMenu } from "./LinkedExperimentsContextMenu";
 
 export const LinkedRoutesTable = ({
   projectId,
   routes,
   treatmentConfigRouteNamePath,
 }) => {
-  const { allExperiments, isAllExperimentsLoaded } = useContext(ExperimentContext)
+  const { allExperiments, isAllExperimentsLoaded } =
+    useContext(ExperimentContext);
 
-  const [routeToExperimentMappings, setRouteToExperimentMappings] = useState(routes.reduce((m, r) => {m[r.id] = {running: {}, scheduled: {}}; return m}, {}));
+  const [routeToExperimentMappings, setRouteToExperimentMappings] = useState(
+    routes.reduce((m, r) => {
+      m[r.id] = { running: {}, scheduled: {} };
+      return m;
+    }, {})
+  );
 
-  const getRouteName = (config, path) => path.split('.').reduce((obj, key) => obj && obj[key], config);
+  const getRouteName = (config, path) =>
+    path.split(".").reduce((obj, key) => obj && obj[key], config);
 
   // this stringified value of routes below allows the React effect below to mimic a deep comparison when changes to the
   // array routes are made
-  const stringifiedRoutes = routes.map(e => e.id).join();
+  const stringifiedRoutes = routes.map((e) => e.id).join();
 
   // reset loaded routeToExperimentMappings if treatmentConfigRouteNamePath or routes changes
   useEffect(() => {
     if (isAllExperimentsLoaded) {
-      let newRouteToExperimentMappings = routes.reduce((m, r) => {m[r.id] = {running: {}, scheduled: {}}; return m}, {});
+      let newRouteToExperimentMappings = routes.reduce((m, r) => {
+        m[r.id] = { running: {}, scheduled: {} };
+        return m;
+      }, {});
       for (let experiment of allExperiments) {
         for (let treatment of experiment.treatments) {
-          let configRouteName = getRouteName(treatment.configuration, treatmentConfigRouteNamePath);
-          if (typeof configRouteName === 'string' && configRouteName in newRouteToExperimentMappings) {
-            newRouteToExperimentMappings[configRouteName][getExperimentStatus(experiment).label.toLowerCase()][experiment.id] = experiment;
+          let configRouteName = getRouteName(
+            treatment.configuration,
+            treatmentConfigRouteNamePath
+          );
+          if (
+            typeof configRouteName === "string" &&
+            configRouteName in newRouteToExperimentMappings
+          ) {
+            newRouteToExperimentMappings[configRouteName][
+              getExperimentStatus(experiment).label.toLowerCase()
+            ][experiment.id] = experiment;
           }
         }
       }
       setRouteToExperimentMappings(newRouteToExperimentMappings);
     }
-  }, [treatmentConfigRouteNamePath, stringifiedRoutes, routes, isAllExperimentsLoaded, allExperiments]);
+  }, [
+    treatmentConfigRouteNamePath,
+    stringifiedRoutes,
+    routes,
+    isAllExperimentsLoaded,
+    allExperiments,
+  ]);
 
   const columns = [
     {
       field: "id",
       width: "5px",
       render: (id) => {
-        const isAssigned = routeToExperimentMappings[id] ?
-          Object.keys(routeToExperimentMappings[id].running).length +
-          Object.keys(routeToExperimentMappings[id].scheduled).length > 0 : false;
+        const isAssigned = routeToExperimentMappings[id]
+          ? Object.keys(routeToExperimentMappings[id].running).length +
+              Object.keys(routeToExperimentMappings[id].scheduled).length >
+            0
+          : false;
         return (
           <EuiIcon
             type={isAssigned ? "check" : "cross"}
@@ -67,35 +94,43 @@ export const LinkedRoutesTable = ({
       width: "20%",
       name: "Route Name",
       render: (id) => {
-        const isAssigned = routeToExperimentMappings[id] ?
-          Object.keys(routeToExperimentMappings[id].running).length +
-          Object.keys(routeToExperimentMappings[id].scheduled).length > 0 : false;
-        return (<EuiTextColor color={isAssigned ? "success" : "danger"}>{id}</EuiTextColor>);
+        const isAssigned = routeToExperimentMappings[id]
+          ? Object.keys(routeToExperimentMappings[id].running).length +
+              Object.keys(routeToExperimentMappings[id].scheduled).length >
+            0
+          : false;
+        return (
+          <EuiTextColor color={isAssigned ? "success" : "danger"}>
+            {id}
+          </EuiTextColor>
+        );
       },
     },
     {
       field: "id",
       width: "35%",
       name: "Running Experiments",
-      render: (id) => routeToExperimentMappings[id] && (
-        <LinkedExperimentsContextMenu
-          projectId={projectId}
-          linkedExperiments={routeToExperimentMappings[id]}
-          experimentStatus={"running"}
-        />
-      ),
+      render: (id) =>
+        routeToExperimentMappings[id] && (
+          <LinkedExperimentsContextMenu
+            projectId={projectId}
+            linkedExperiments={routeToExperimentMappings[id]}
+            experimentStatus={"running"}
+          />
+        ),
     },
     {
       field: "id",
       width: "35%",
       name: "Scheduled Experiments",
-      render: (id) => routeToExperimentMappings[id] && (
-        <LinkedExperimentsContextMenu
-          projectId={projectId}
-          linkedExperiments={routeToExperimentMappings[id]}
-          experimentStatus={"scheduled"}
-        />
-      )
+      render: (id) =>
+        routeToExperimentMappings[id] && (
+          <LinkedExperimentsContextMenu
+            projectId={projectId}
+            linkedExperiments={routeToExperimentMappings[id]}
+            experimentStatus={"scheduled"}
+          />
+        ),
     },
   ];
 
@@ -108,9 +143,9 @@ export const LinkedRoutesTable = ({
         isSelectable={false}
       />
     </EuiFlexItem>
-    ) : (
-      <EuiTextAlign textAlign={"center"}>
-        <EuiLoadingChart size={"xl"} mono />
-      </EuiTextAlign>
-    );
+  ) : (
+    <EuiTextAlign textAlign={"center"}>
+      <EuiLoadingChart size={"xl"} mono />
+    </EuiTextAlign>
+  );
 };

--- a/ui/src/turing/components/form/standard_ensembler/RouteNamePathFlyout.js
+++ b/ui/src/turing/components/form/standard_ensembler/RouteNamePathFlyout.js
@@ -1,27 +1,25 @@
 import React from "react";
 
 import {
+  EuiCode,
+  EuiCodeBlock,
   EuiFlexItem,
   EuiFlyout,
   EuiFlyoutBody,
   EuiFlyoutHeader,
   EuiText,
   EuiTitle,
-  EuiCode,
-  EuiCodeBlock
 } from "@elastic/eui";
-import {useConfig} from "config";
+
+import { useConfig } from "config";
 
 const RouteNamePathFlyout = ({ onClose }) => {
-  const { appConfig: { routeNamePathPrefix } } = useConfig();
+  const {
+    appConfig: { routeNamePathPrefix },
+  } = useConfig();
 
   return (
-    <EuiFlyout
-      ownFocus
-      onClose={onClose}
-      size={"s"}
-      paddingSize="m"
-    >
+    <EuiFlyout ownFocus onClose={onClose} size={"s"} paddingSize="m">
       <EuiFlyoutHeader hasBorder>
         <EuiFlexItem>
           <EuiTitle size="s">
@@ -34,28 +32,30 @@ const RouteNamePathFlyout = ({ onClose }) => {
           <EuiFlexItem>
             <EuiText>
               <p>
-                The prefix in the grayed-out area specifies the path prefix that gets appended to a user-defined
-                treatment configuration.
+                The prefix in the grayed-out area specifies the path prefix that
+                gets appended to a user-defined treatment configuration.
               </p>
 
               <p>
-                This path prefix reflects the nesting of the treatment configuration within
-                the final response payload that the Turing Router finally receives.
+                This path prefix reflects the nesting of the treatment
+                configuration within the final response payload that the Turing
+                Router finally receives.
               </p>
 
               <p>
-                In Turing Experiments' case, if the user-defined treatment configuration is:
+                In Turing Experiments' case, if the user-defined treatment
+                configuration is:
               </p>
               <EuiCodeBlock language="json" fontSize="m" paddingSize="m">
                 {`{
     "route_name": "control",
     ...
-}`
-                }
+}`}
               </EuiCodeBlock>
 
               <p>
-                the client response that gets sent back to the Turing Router is actually as follows:
+                the client response that gets sent back to the Turing Router is
+                actually as follows:
               </p>
               <EuiCodeBlock language="json" fontSize="m" paddingSize="m">
                 {`{
@@ -67,13 +67,13 @@ const RouteNamePathFlyout = ({ onClose }) => {
         ....
     }
     ...
-}`
-                }
+}`}
               </EuiCodeBlock>
 
               <p>
                 Hence, the path prefix is automatically specified as
-                <EuiCode language="json">{routeNamePathPrefix}</EuiCode> (including the final period).
+                <EuiCode language="json">{routeNamePathPrefix}</EuiCode>{" "}
+                (including the final period).
               </p>
             </EuiText>
           </EuiFlexItem>

--- a/ui/src/turing/components/form/standard_ensembler/RouteNamePathRow.js
+++ b/ui/src/turing/components/form/standard_ensembler/RouteNamePathRow.js
@@ -1,7 +1,14 @@
 import React, { Fragment } from "react";
 
-import { EuiFlexItem, EuiText, EuiFormRow, EuiFieldText, EuiButtonIcon } from "@elastic/eui";
+import {
+  EuiButtonIcon,
+  EuiFieldText,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiText,
+} from "@elastic/eui";
 import { FormLabelWithToolTip, useToggle } from "@gojek/mlp-ui";
+
 import RouteNamePathFlyout from "./RouteNamePathFlyout";
 
 export const RouteNamePathRow = ({
@@ -25,7 +32,8 @@ export const RouteNamePathRow = ({
           }
           isInvalid={!!errors}
           error={errors}
-          display="row">
+          display="row"
+        >
           <EuiFieldText
             fullWidth
             placeholder="policy.route_name"
@@ -34,8 +42,11 @@ export const RouteNamePathRow = ({
             isInvalid={!!errors}
             name="route-name-path"
             prepend={[
-              <EuiButtonIcon iconType="questionInCircle" onClick={toggleFlyout}/>,
-              <EuiText size={"s"}>{routeNamePathPrefix}</EuiText>
+              <EuiButtonIcon
+                iconType="questionInCircle"
+                onClick={toggleFlyout}
+              />,
+              <EuiText size={"s"}>{routeNamePathPrefix}</EuiText>,
             ]}
           />
         </EuiFormRow>

--- a/ui/src/turing/components/form/variables_config/VariableConfigRow.js
+++ b/ui/src/turing/components/form/variables_config/VariableConfigRow.js
@@ -17,6 +17,7 @@ export const VariableConfigRow = ({
   name,
   field,
   fieldSrc,
+  protocol,
   onChangeHandler,
   error = {},
 }) => {
@@ -35,12 +36,14 @@ export const VariableConfigRow = ({
       direction="row"
       gutterSize="m"
       alignItems="center"
-      className="euiFlexGroup--experimentVariableRow">
+      className="euiFlexGroup--experimentVariableRow"
+    >
       <EuiFlexItem grow={true} className="eui-textTruncate">
         <EuiFormRow
           fullWidth
           isInvalid={!!error.field}
-          error={error.field || ""}>
+          error={error.field || ""}
+        >
           <EuiFieldText
             fullWidth
             compressed
@@ -52,6 +55,7 @@ export const VariableConfigRow = ({
             prepend={
               <FieldSourceFormLabel
                 readOnly={false}
+                protocol={protocol}
                 value={fieldSrc}
                 onChange={(e) => onChangeFieldSource(e)}
               />

--- a/ui/src/turing/components/form/variables_config/VariablesConfigPanel.js
+++ b/ui/src/turing/components/form/variables_config/VariablesConfigPanel.js
@@ -10,6 +10,7 @@ import { VariableConfigRow } from "./VariableConfigRow";
 
 export const VariablesConfigPanel = ({
   variables = [],
+  protocol,
   onChangeHandler,
   errors = {},
 }) => {
@@ -46,8 +47,8 @@ export const VariablesConfigPanel = ({
           size="m"
           content="Specify how the experiment variables may be parsed from the request."
         />
-      }>
-
+      }
+    >
       <EuiSpacer size="xs" />
       <EuiFlexItem>
         <EuiFlexGroup direction="column" gutterSize="s">
@@ -55,6 +56,7 @@ export const VariablesConfigPanel = ({
             <EuiFlexItem key={`experiment-variable-${variable.name}`}>
               <VariableConfigRow
                 name={variable.name}
+                protocol={protocol}
                 field={variable.field}
                 fieldSrc={variable.field_source}
                 onChangeHandler={onChange(`${idx}`)}

--- a/ui/src/turing/components/form/variables_config/components/FieldSourceFormLabel.js
+++ b/ui/src/turing/components/form/variables_config/components/FieldSourceFormLabel.js
@@ -10,23 +10,30 @@ import { flattenPanelTree, useToggle } from "@gojek/mlp-ui";
 
 import "./FieldSourceFormLabel.scss";
 
-const fieldSourceOptions = [
-  {
-    value: "none",
-    inputDisplay: "None",
-  },
-  {
-    value: "header",
-    inputDisplay: "Header",
-  },
-  {
-    value: "payload",
-    inputDisplay: "Payload",
-  },
-];
-
-export const FieldSourceFormLabel = ({ value, onChange, readOnly }) => {
+export const FieldSourceFormLabel = ({
+  value,
+  protocol,
+  onChange,
+  readOnly,
+}) => {
   const [isOpen, togglePopover] = useToggle();
+
+  const fieldSourceOptions = [
+    {
+      value: "none",
+      inputDisplay: "None",
+    },
+    {
+      value: "header",
+      inputDisplay: "Header",
+    },
+    {
+      value: "payload",
+      // Display is change to Prediction Context to be consistent with Turing Traffic rule
+      // backend value stays the same as payload, because XP is not supporting gRPC
+      inputDisplay: protocol === "UPI_V1" ? "Prediction Context" : "Payload",
+    },
+  ];
 
   const panels = flattenPanelTree({
     id: 0,
@@ -57,13 +64,15 @@ export const FieldSourceFormLabel = ({ value, onChange, readOnly }) => {
           iconType="arrowDown"
           iconSide="right"
           className="fieldSourceLabel"
-          onClick={togglePopover}>
+          onClick={togglePopover}
+        >
           {selectedOption.inputDisplay}
         </EuiButtonEmpty>
       }
       isOpen={isOpen}
       closePopover={togglePopover}
-      panelPaddingSize="s">
+      panelPaddingSize="s"
+    >
       <EuiContextMenu
         className="fieldSourceDropdown"
         initialPanelId={0}

--- a/ui/src/turing/components/form/variables_config/components/FieldSourceFormLabel.js
+++ b/ui/src/turing/components/form/variables_config/components/FieldSourceFormLabel.js
@@ -8,6 +8,11 @@ import {
 } from "@elastic/eui";
 import { flattenPanelTree, useToggle } from "@gojek/mlp-ui";
 
+import {
+  capitalizeFirstLetter,
+  mapProtocolLabel,
+} from "turing/components/utils/helper";
+
 import "./FieldSourceFormLabel.scss";
 
 export const FieldSourceFormLabel = ({
@@ -18,22 +23,27 @@ export const FieldSourceFormLabel = ({
 }) => {
   const [isOpen, togglePopover] = useToggle();
 
-  const fieldSourceOptions = [
-    {
-      value: "none",
-      inputDisplay: "None",
-    },
-    {
-      value: "header",
-      inputDisplay: "Header",
-    },
-    {
-      value: "payload",
-      // Display is change to Prediction Context to be consistent with Turing Traffic rule
-      // backend value stays the same as payload, because XP is not supporting gRPC
-      inputDisplay: protocol === "UPI_V1" ? "Prediction Context" : "Payload",
-    },
-  ];
+  const fieldSourceOptions = useMemo(
+    () => [
+      {
+        value: "none",
+        inputDisplay: "None",
+      },
+      {
+        value: "header",
+        inputDisplay: "Header",
+      },
+      {
+        value: "payload",
+        // Display is change to Prediction Context to be consistent with Turing Traffic rule
+        // backend value stays the same as payload, because XP is not supporting gRPC
+        inputDisplay: capitalizeFirstLetter(
+          mapProtocolLabel(protocol, "payload")
+        ),
+      },
+    ],
+    [protocol]
+  );
 
   const panels = flattenPanelTree({
     id: 0,
@@ -49,7 +59,7 @@ export const FieldSourceFormLabel = ({
 
   const selectedOption = useMemo(
     () => fieldSourceOptions.find((o) => o.value === value),
-    [value]
+    [value, fieldSourceOptions]
   );
 
   return readOnly ? (

--- a/ui/src/turing/components/form/variables_config/components/FieldSourceFormLabel.js
+++ b/ui/src/turing/components/form/variables_config/components/FieldSourceFormLabel.js
@@ -7,11 +7,9 @@ import {
   EuiPopover,
 } from "@elastic/eui";
 import { flattenPanelTree, useToggle } from "@gojek/mlp-ui";
+import startCase from "lodash/startCase";
 
-import {
-  capitalizeFirstLetter,
-  mapProtocolLabel,
-} from "turing/components/utils/helper";
+import { mapProtocolLabel } from "turing/components/utils/helper";
 
 import "./FieldSourceFormLabel.scss";
 
@@ -37,9 +35,7 @@ export const FieldSourceFormLabel = ({
         value: "payload",
         // Display is change to Prediction Context to be consistent with Turing Traffic rule
         // backend value stays the same as payload, because XP is not supporting gRPC
-        inputDisplay: capitalizeFirstLetter(
-          mapProtocolLabel(protocol, "payload")
-        ),
+        inputDisplay: startCase(mapProtocolLabel(protocol, "payload")),
       },
     ],
     [protocol]

--- a/ui/src/turing/components/utils/helper.js
+++ b/ui/src/turing/components/utils/helper.js
@@ -5,7 +5,3 @@ export const mapProtocolLabel = (protocol, value) => {
 
   return value;
 };
-
-export const capitalizeFirstLetter = (string) => {
-  return string.replace(/(^\w|\s\w)/g, (m) => m.toUpperCase());
-};

--- a/ui/src/turing/components/utils/helper.js
+++ b/ui/src/turing/components/utils/helper.js
@@ -1,0 +1,11 @@
+export const mapProtocolLabel = (protocol, value) => {
+  if (protocol === "UPI_V1" && value === "payload") {
+    return "prediction context";
+  }
+
+  return value;
+};
+
+export const capitalizeFirstLetter = (string) => {
+  return string.replace(/(^\w|\s\w)/g, (m) => m.toUpperCase());
+};


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/caraml-dev/xp/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/caraml-dev/xp/blob/master/CONTRIBUTING.md#unit-tests
3. Make sure documentation is updated for your PR

-->

**What this PR does / why we need it**:
UI enhancement to support UPI routers in Turing. Most code changes are due to formatting. 

The only main change is from / `xp/ui/src/turing/components/form/EditExperimentEngineConfig.js` whereby protocol is passed from Turing, all the way to `xp/ui/src/turing/components/form/variables_config/components/FieldSourceFormLabel.js`. 

The value of `Prediction Context` stays the same as payload, as XP only supports HTTP, it is the Turing router that parses the UPI proto and send it to XP. This is mainly for visual aid to be consistency with traffic rules which shows `Prediction Context` too.

If no protocol is passed in, the original `Payload` will be shown.

<img width="785" alt="image" src="https://user-images.githubusercontent.com/30390872/198561126-382ea4ec-e9c8-4cc7-97f3-dc2d79a9eabf.png">
