### PR TITLE
Bugfix: Edit Experiment projectId

### DIFF
--- a/ui/src/experiments/edit/EditExperimentView.js
+++ b/ui/src/experiments/edit/EditExperimentView.js
@@ -12,7 +12,8 @@ import { TreatmentContextProvider } from "providers/treatment/context";
 import { Experiment } from "services/experiment/Experiment";
 import { PageTitle } from "components/page/PageTitle";
 
-const EditExperimentView = ({ projectId, experimentSpec }) => {
+const EditExperimentView = ({ experimentSpec }) => {
+  const projectId = experimentSpec.project_id;
   const navigate = useNavigate();
   useEffect(() => {
     replaceBreadcrumbs([

--- a/ui/src/settings/components/form/components/segmenter_section/SegmenterSettings.js
+++ b/ui/src/settings/components/form/components/segmenter_section/SegmenterSettings.js
@@ -75,7 +75,12 @@ export const SegmenterSettings = ({
       buttonContent={buttonContent}
       arrowDisplay="none"
       extraAction={
-        <EuiButtonIcon size="s" iconType={"gear"} color={"text"} onClick={() => setIsOpen(!isOpen)} />
+        <EuiButtonIcon
+          size="s" iconType={"gear"}
+          color={"text"}
+          onClick={() => setIsOpen(!isOpen)}
+          aria-label="segmenter-settings"
+        />
       }
     >
       <EuiHorizontalRule margin="xs" />

--- a/ui/src/turing/components/form/standard_ensembler/RouteNamePathRow.js
+++ b/ui/src/turing/components/form/standard_ensembler/RouteNamePathRow.js
@@ -45,6 +45,7 @@ export const RouteNamePathRow = ({
               <EuiButtonIcon
                 iconType="questionInCircle"
                 onClick={toggleFlyout}
+                aria-label="route-name-path-help"
               />,
               <EuiText size={"s"}>{routeNamePathPrefix}</EuiText>,
             ]}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/caraml-dev/xp/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/caraml-dev/xp/blob/master/CONTRIBUTING.md#unit-tests
3. Make sure documentation is updated for your PR

-->

**What this PR does / why we need it**: This PR addresses a regression from https://github.com/caraml-dev/xp/pull/45, which caused the Edit experiment view to crash, as we were not retrieving the `projectId` correctly, for passing to the downstream components.

In addition, the following warning related to `EuiButtonIcon` has been fixed:

<img width="828" alt="Screenshot 2022-11-04 at 1 14 11 PM" src="https://user-images.githubusercontent.com/23465343/199895605-c1d0dbff-512d-459a-bc86-50c77793626a.png">
