### PR TITLE
Init empty array for List experiments response

### DIFF
--- a/management-service/controller/experiment_controller.go
+++ b/management-service/controller/experiment_controller.go
@@ -86,7 +86,7 @@ func (e ExperimentController) ListExperiments(w http.ResponseWriter, r *http.Req
 		WriteErrorResponse(w, err)
 		return
 	}
-	var expsResp []schema.Experiment
+	expsResp := []schema.Experiment{}
 	var fields []models.ExperimentField
 	if listExperimentParams.Fields != nil {
 		fields = *listExperimentParams.Fields


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/caraml-dev/xp/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/caraml-dev/xp/blob/master/CONTRIBUTING.md#unit-tests
3. Make sure documentation is updated for your PR

-->

**What this PR does / why we need it**: This is a minor bugfix for the List Experiments API when 0 records are selected from the DB. We subsequently iterate over the experiments and copy only the required fields (specified by the field selector, if set), to a new array. However, this array was previously uninitialised, leading to `"data": null` as opposed to `"data": []` in the response. (This is implemented correctly for other entities like Segments and Treatments already.)