### PR TITLE
Remove redundant configs from experiment runner

### DIFF
--- a/plugins/turing/config/config.go
+++ b/plugins/turing/config/config.go
@@ -22,11 +22,6 @@ const (
 	NoneFieldSource FieldSource = "none"
 )
 
-type RunnerDefaults struct {
-	Endpoint string `json:"endpoint"` // API host for the experiment runner
-	Timeout  string `json:"timeout"`  // API timeout for the experiment runner
-}
-
 type RemoteUI struct {
 	Name   string `json:"name" validate:"required"`
 	URL    string `json:"url" validate:"required"`
@@ -38,14 +33,11 @@ type ExperimentManagerConfig struct {
 	BaseURL                      string                       `json:"base_url"`      // Base URL for XP experiment REST API
 	HomePageURL                  string                       `json:"home_page_url"` // Website URL for end-users to manage experiments
 	RemoteUI                     RemoteUI                     `json:"remote_ui"`
-	RunnerDefaults               RunnerDefaults               `json:"runner_defaults"`
 	TreatmentServicePluginConfig TreatmentServicePluginConfig `json:"treatment_service_plugin_config"`
 }
 
 // ExperimentRunnerConfig is used to parse the XP runner config during initialization
 type ExperimentRunnerConfig struct {
-	Endpoint               string         `json:"endpoint" validate:"required"`
-	Timeout                string         `json:"timeout" validate:"required"`
 	RequestParameters      []Variable     `json:"request_parameters" validate:"required,dive"`
 	TreatmentServiceConfig *config.Config `json:"treatment_service_config" validate:"required,dive"`
 }

--- a/plugins/turing/config/config.go
+++ b/plugins/turing/config/config.go
@@ -45,7 +45,6 @@ type ExperimentManagerConfig struct {
 // ExperimentRunnerConfig is used to parse the XP runner config during initialization
 type ExperimentRunnerConfig struct {
 	Endpoint               string         `json:"endpoint" validate:"required"`
-	ProjectID              int            `json:"project_id" validate:"required"`
 	Timeout                string         `json:"timeout" validate:"required"`
 	RequestParameters      []Variable     `json:"request_parameters" validate:"required,dive"`
 	TreatmentServiceConfig *config.Config `json:"treatment_service_config" validate:"required,dive"`

--- a/plugins/turing/manager/experiment_manager.go
+++ b/plugins/turing/manager/experiment_manager.go
@@ -60,7 +60,6 @@ type experimentManager struct {
 	validate                     *validator.Validate
 	httpClient                   *xpclient.ClientWithResponses
 	RemoteUI                     _config.RemoteUI                     `validate:"required,dive"`
-	RunnerDefaults               _config.RunnerDefaults               `validate:"required,dive"`
 	TreatmentServicePluginConfig _config.TreatmentServicePluginConfig `validate:"required,dive"`
 }
 
@@ -103,8 +102,6 @@ func (em *experimentManager) GetExperimentRunnerConfig(rawConfig json.RawMessage
 
 	// Convert data to json
 	bytes, err := json.Marshal(_config.ExperimentRunnerConfig{
-		Endpoint:               em.RunnerDefaults.Endpoint,
-		Timeout:                em.RunnerDefaults.Timeout,
 		RequestParameters:      config.Variables,
 		TreatmentServiceConfig: treatmentServiceConfig,
 	})
@@ -192,7 +189,6 @@ func NewExperimentManager(configData json.RawMessage) (manager.CustomExperimentM
 		validate:                     _config.NewValidator(),
 		httpClient:                   client,
 		RemoteUI:                     config.RemoteUI,
-		RunnerDefaults:               config.RunnerDefaults,
 		TreatmentServicePluginConfig: config.TreatmentServicePluginConfig,
 	}
 

--- a/plugins/turing/manager/experiment_manager.go
+++ b/plugins/turing/manager/experiment_manager.go
@@ -105,7 +105,6 @@ func (em *experimentManager) GetExperimentRunnerConfig(rawConfig json.RawMessage
 	bytes, err := json.Marshal(_config.ExperimentRunnerConfig{
 		Endpoint:               em.RunnerDefaults.Endpoint,
 		Timeout:                em.RunnerDefaults.Timeout,
-		ProjectID:              config.ProjectID,
 		RequestParameters:      config.Variables,
 		TreatmentServiceConfig: treatmentServiceConfig,
 	})

--- a/plugins/turing/manager/experiment_manager_test.go
+++ b/plugins/turing/manager/experiment_manager_test.go
@@ -158,7 +158,6 @@ func TestGetExperimentRunnerConfig(t *testing.T) {
 			}`),
 			expected: `{
 				"endpoint": "test-endpoint",
-				"project_id": 10,
 				"timeout": "12s",
 				"request_parameters": [
 					{

--- a/plugins/turing/manager/experiment_manager_test.go
+++ b/plugins/turing/manager/experiment_manager_test.go
@@ -45,10 +45,6 @@ func TestNewExperimentManager(t *testing.T) {
 					"name": "xp",
 					"url": "/xp/remoteEntry.js"
 				},
-				"runner_defaults": {
-					"endpoint": "http://xp-treatment.global.io/v1",
-					"timeout": "5s"
-				},
 				"treatment_service_plugin_config": {
 					"assigned_treatment_logger": {
 						"bq_config": {
@@ -157,8 +153,6 @@ func TestGetExperimentRunnerConfig(t *testing.T) {
 				]
 			}`),
 			expected: `{
-				"endpoint": "test-endpoint",
-				"timeout": "12s",
 				"request_parameters": [
 					{
 						"name": "country",
@@ -178,7 +172,7 @@ func TestGetExperimentRunnerConfig(t *testing.T) {
 
 	// Patch method to get treatment service config
 	// TODO: Generate mock client and use it here instead of patching
-	em := &experimentManager{RunnerDefaults: _config.RunnerDefaults{Endpoint: "test-endpoint", Timeout: "12s"}}
+	em := &experimentManager{}
 	monkey.PatchInstanceMethod(
 		reflect.TypeOf(em),
 		"GetTreatmentServiceConfigFromManagementService",

--- a/plugins/turing/runner/experiment_runner_test.go
+++ b/plugins/turing/runner/experiment_runner_test.go
@@ -33,8 +33,6 @@ func TestNewExperimentRunner(t *testing.T) {
 	}{
 		"success": {
 			props: json.RawMessage(`{
-				"endpoint": "http://test-endpoint",
-				"timeout": "500ms",
 				"request_parameters": [
 					{
 						"name": "country",
@@ -93,73 +91,14 @@ func TestNewExperimentRunner(t *testing.T) {
 		"failure | missing config": {
 			props: json.RawMessage(`{}`),
 			err: fmt.Sprint(
-				"Key: 'ExperimentRunnerConfig.Endpoint' Error:",
-				"Field validation for 'Endpoint' failed on the 'required' tag\n",
-				"Key: 'ExperimentRunnerConfig.Timeout' Error:",
-				"Field validation for 'Timeout' failed on the 'required' tag\n",
 				"Key: 'ExperimentRunnerConfig.RequestParameters' Error:",
 				"Field validation for 'RequestParameters' failed on the 'required' tag\n",
 				"Key: 'ExperimentRunnerConfig.TreatmentServiceConfig' Error:",
 				"Field validation for 'TreatmentServiceConfig' failed on the 'required' tag",
 			),
 		},
-		"failure | bad timeout": {
-			props: json.RawMessage(`{
-				"endpoint": "http://test-endpoint",
-				"timeout": "500ss",
-				"request_parameters": [
-					{
-						"name": "country",
-						"field": "countryValue",
-						"field_source": "payload"
-					}
-				],
-				"treatment_service_config": {
-										"assigned_treatment_logger": {
-						"bq_config": {
-							"dataset": "xp_dataset",
-							"project": "xp_project",
-							"table": "xp_table"
-						},
-						"kind": "bq",
-						"queue_length": 100000
-					},
-					"debug_config": {
-						"output_path": "/tmp"
-					},
-					"pub_sub": {
-						"project": "dev",
-						"topic_name": "xp-update",
-						"pub_sub_timeout_seconds": 30
-					},
-					"deployment_config": {
-						"environment_type": "dev",
-						"max_go_routines": 200
-					},
-					"management_service": {
-						"authorization_enabled": true,
-						"url": "http://xp-management.global.io/api/xp/v1"
-					},
-					"monitoring_config": {
-						"kind": "prometheus",
-						"metric_labels": [
-							"country",
-							"service"
-						]
-					},
-					"port": 8080,
-					"project_ids": ["1"],
-					"swagger_config": {
-						"enabled": false
-					}
-				}
-			}`),
-			err: "XP runner timeout 500ss is invalid",
-		},
 		"failure | bad treatment service config": {
 			props: json.RawMessage(`{
-				"endpoint": "http://test-endpoint",
-				"timeout": "500ss",
 				"request_parameters": [
 					{
 						"name": "country",
@@ -211,8 +150,6 @@ func TestNewExperimentRunner(t *testing.T) {
 		},
 		"failure | 0 project ids specified": {
 			props: json.RawMessage(`{
-				"endpoint": "http://test-endpoint",
-				"timeout": "500ms",
 				"request_parameters": [
 					{
 						"name": "country",
@@ -263,8 +200,6 @@ func TestNewExperimentRunner(t *testing.T) {
 		},
 		"failure | project id specified cannot be parsed into an int64 data type": {
 			props: json.RawMessage(`{
-				"endpoint": "http://test-endpoint",
-				"timeout": "500ms",
 				"request_parameters": [
 					{
 						"name": "country",


### PR DESCRIPTION
**What this PR does / why we need it**:
After the plugin has been refactored to incorporate the Treatment Service, it has been found that there were a couple of redundant fields that were left hanging in the experiment manager/runner configs that were passed around. This PR simply serves to remove those fields from the said configs:
- `ExperimentManagerConfig.RunnerDefaults` - since the plugin no longer communicates with a central Treatment Service, there is no need for an API endpoint or timeout value
- `ExperimentRunnerConfig.Endpoint` -  same as above
- `ExperimentRunnerConfig.Timeout` - same as above
- `ExperimentRunnerConfig.ProjectID` - this value is a duplicate of the value found in `ExperimentRunnerConfig.TreatmentServiceConfig.ProjectIds`
