### PR TITLE
Reduce treatment service memory usage

### DIFF
--- a/common/utils/typeconverter.go
+++ b/common/utils/typeconverter.go
@@ -13,11 +13,11 @@ func StringSliceToListSegmenterValue(values *[]string) *_segmenters.ListSegmente
 	if values == nil {
 		return nil
 	}
-	segmenterValues := []*_segmenters.SegmenterValue{}
-	for _, val := range *values {
-		segmenterValues = append(segmenterValues, &_segmenters.SegmenterValue{
-			Value: &_segmenters.SegmenterValue_String_{String_: val},
-		})
+	segmenterValues := make([]*_segmenters.SegmenterValue, len(*values))
+	for i := 0; i < len(*values); i++ {
+		segmenterValues[i] = &_segmenters.SegmenterValue{
+			Value: &_segmenters.SegmenterValue_String_{String_: (*values)[i]},
+		}
 	}
 	return &_segmenters.ListSegmenterValue{Values: segmenterValues}
 }
@@ -26,9 +26,11 @@ func BoolSliceToListSegmenterValue(values *[]bool) *_segmenters.ListSegmenterVal
 	if values == nil {
 		return nil
 	}
-	segmenterValues := []*_segmenters.SegmenterValue{}
-	for _, val := range *values {
-		segmenterValues = append(segmenterValues, &_segmenters.SegmenterValue{Value: &_segmenters.SegmenterValue_Bool{Bool: val}})
+	segmenterValues := make([]*_segmenters.SegmenterValue, len(*values))
+	for i := 0; i < len(*values); i++ {
+		segmenterValues[i] = &_segmenters.SegmenterValue{
+			Value: &_segmenters.SegmenterValue_Bool{Bool: (*values)[i]},
+		}
 	}
 	return &_segmenters.ListSegmenterValue{Values: segmenterValues}
 }
@@ -37,11 +39,11 @@ func Int64ListToListSegmenterValue(values *[]int64) *_segmenters.ListSegmenterVa
 	if values == nil {
 		return nil
 	}
-	segmenterValues := []*_segmenters.SegmenterValue{}
-	for _, val := range *values {
-		segmenterValues = append(segmenterValues, &_segmenters.SegmenterValue{
-			Value: &_segmenters.SegmenterValue_Integer{Integer: val},
-		})
+	segmenterValues := make([]*_segmenters.SegmenterValue, len(*values))
+	for i := 0; i < len(*values); i++ {
+		segmenterValues[i] = &_segmenters.SegmenterValue{
+			Value: &_segmenters.SegmenterValue_Integer{Integer: (*values)[i]},
+		}
 	}
 	return &_segmenters.ListSegmenterValue{Values: segmenterValues}
 }
@@ -50,11 +52,11 @@ func FloatListToListSegmenterValue(values *[]float64) *_segmenters.ListSegmenter
 	if values == nil {
 		return nil
 	}
-	segmenterValues := []*_segmenters.SegmenterValue{}
-	for _, val := range *values {
-		segmenterValues = append(segmenterValues, &_segmenters.SegmenterValue{
-			Value: &_segmenters.SegmenterValue_Real{Real: val},
-		})
+	segmenterValues := make([]*_segmenters.SegmenterValue, len(*values))
+	for i := 0; i < len(*values); i++ {
+		segmenterValues[i] = &_segmenters.SegmenterValue{
+			Value: &_segmenters.SegmenterValue_Real{Real: (*values)[i]},
+		}
 	}
 	return &_segmenters.ListSegmenterValue{Values: segmenterValues}
 }

--- a/treatment-service/models/storage.go
+++ b/treatment-service/models/storage.go
@@ -159,22 +159,6 @@ func (i *ExperimentIndex) matchFlagSetSegment(segmentName string, value bool) Ma
 	return MatchStrengthNone
 }
 
-func (i *ExperimentIndex) checkSegmentHasWeakMatch(segmentName string) bool {
-	if set, exists := i.stringSets[segmentName]; !exists || set.Len() == 0 {
-		return true
-	}
-	if set, exists := i.intSets[segmentName]; !exists || set.Len() == 0 {
-		return true
-	}
-	if set, exists := i.realSets[segmentName]; !exists || set.Len() == 0 {
-		return true
-	}
-	if _, exists := i.boolFlags[segmentName]; !exists {
-		return true
-	}
-	return false
-}
-
 func (i *ExperimentIndex) matchStringSetSegment(segmentName string, value string) MatchStrength {
 	set, exists := i.stringSets[segmentName]
 	if !exists || set.Len() == 0 {
@@ -248,6 +232,22 @@ func (i *ExperimentIndex) isActive() bool {
 	}
 
 	return (i.StartTime.Before(time.Now()) || i.StartTime.Equal(time.Now())) && i.EndTime.After(time.Now())
+}
+
+func (i *ExperimentIndex) checkSegmentHasWeakMatch(segmentName string) bool {
+	if set, exists := i.stringSets[segmentName]; !exists || set.Len() == 0 {
+		return true
+	}
+	if set, exists := i.intSets[segmentName]; !exists || set.Len() == 0 {
+		return true
+	}
+	if set, exists := i.realSets[segmentName]; !exists || set.Len() == 0 {
+		return true
+	}
+	if _, exists := i.boolFlags[segmentName]; !exists {
+		return true
+	}
+	return false
 }
 
 func (s *LocalStorage) InsertProjectSettings(projectSettings *pubsub.ProjectSettings) error {
@@ -403,7 +403,8 @@ func NewExperimentIndex(experiment *pubsub.Experiment) *ExperimentIndex {
 		}
 	}
 
-	// Delete all segments since they are unnecessary
+	// Delete all segments since they have already been converted to the various sets stored in ExperimentIndex,
+	// and are no longer used by the Treatment Service
 	experiment.Segments = nil
 
 	return &ExperimentIndex{

--- a/treatment-service/models/storage.go
+++ b/treatment-service/models/storage.go
@@ -418,6 +418,8 @@ func NewExperimentIndex(experiment *pubsub.Experiment) *ExperimentIndex {
 
 	// Delete all segments since they have already been converted to the various sets stored in ExperimentIndex,
 	// and are no longer used by the Treatment Service
+	// TODO: To make the ExperimentIndex store only the relevant data using appropriate structs rather than
+	// attempting to reuse this pubsub message type and deleting the redundant data from it
 	experiment.Segments = nil
 
 	return &ExperimentIndex{

--- a/treatment-service/models/storage.go
+++ b/treatment-service/models/storage.go
@@ -236,19 +236,27 @@ func (i *ExperimentIndex) isActive() bool {
 }
 
 func (i *ExperimentIndex) checkSegmentHasWeakMatch(segmentName string) bool {
-	if set, exists := i.stringSets[segmentName]; !exists || set.Len() == 0 {
-		return true
+	if set, exists := i.stringSets[segmentName]; exists {
+		if set.Len() > 0 {
+			return false
+		}
 	}
-	if set, exists := i.intSets[segmentName]; !exists || set.Len() == 0 {
-		return true
+	if set, exists := i.intSets[segmentName]; exists {
+		if set.Len() > 0 {
+			return false
+		}
 	}
-	if set, exists := i.realSets[segmentName]; !exists || set.Len() == 0 {
-		return true
+	if set, exists := i.realSets[segmentName]; exists {
+		if set.Len() > 0 {
+			return false
+		}
 	}
-	if _, exists := i.boolSets[segmentName]; !exists {
-		return true
+	if set, exists := i.boolSets[segmentName]; exists {
+		if set.Len() > 0 {
+			return false
+		}
 	}
-	return false
+	return true
 }
 
 func (s *LocalStorage) InsertProjectSettings(projectSettings *pubsub.ProjectSettings) error {

--- a/treatment-service/models/storage.go
+++ b/treatment-service/models/storage.go
@@ -240,18 +240,15 @@ func (i *ExperimentIndex) checkSegmentHasWeakMatch(segmentName string) bool {
 		if set.Len() > 0 {
 			return false
 		}
-	}
-	if set, exists := i.intSets[segmentName]; exists {
+	} else if set, exists := i.intSets[segmentName]; exists {
 		if set.Len() > 0 {
 			return false
 		}
-	}
-	if set, exists := i.realSets[segmentName]; exists {
+	} else if set, exists := i.realSets[segmentName]; exists {
 		if set.Len() > 0 {
 			return false
 		}
-	}
-	if set, exists := i.boolSets[segmentName]; exists {
+	} else if set, exists := i.boolSets[segmentName]; exists {
 		if set.Len() > 0 {
 			return false
 		}

--- a/treatment-service/models/storage_test.go
+++ b/treatment-service/models/storage_test.go
@@ -570,6 +570,9 @@ func TestExperimentIndexMatchSegment(t *testing.T) {
 		realSets: map[string]*set.Set{
 			"realType": set.New(realSetsVal...),
 		},
+		boolFlags: map[string]bool{
+			"flagType": true,
+		},
 		Experiment: &_pubsub.Experiment{
 			Segments: map[string]*_segmenters.ListSegmenterValue{
 				"stringType": {
@@ -672,7 +675,7 @@ func TestExperimentIndexMatchSegment(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := experimentIndex.matchSegment(tt.args.segmentName, tt.args.value)
-			assert.Equal(t, got, tt.want)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/treatment-service/models/storage_test.go
+++ b/treatment-service/models/storage_test.go
@@ -560,6 +560,7 @@ func TestExperimentIndexMatchSegment(t *testing.T) {
 	stringSetsVal := []interface{}{"test1"}
 	intSetsVal := []interface{}{int64(1)}
 	realSetsVal := []interface{}{1.0}
+	boolSetsVal := []interface{}{true}
 	experimentIndex := ExperimentIndex{
 		stringSets: map[string]*set.Set{
 			"stringType": set.New(stringSetsVal...),
@@ -570,8 +571,8 @@ func TestExperimentIndexMatchSegment(t *testing.T) {
 		realSets: map[string]*set.Set{
 			"realType": set.New(realSetsVal...),
 		},
-		boolFlags: map[string]bool{
-			"flagType": true,
+		boolSets: map[string]*set.Set{
+			"flagType": set.New(boolSetsVal...),
 		},
 		Experiment: &_pubsub.Experiment{
 			Segments: map[string]*_segmenters.ListSegmenterValue{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces some minor refactoring that reduces the memory usage of the Treatment Service by removing the redundancy in storing segmenter values twice in the `ExperimentIndex` struct:
- in the various sets, i.e. `ExperimentIndex.stringSets`, `ExperimentIndex.intSets`, `ExperimentIndex.realSets` 
- in the field `ExperimentIndex.Experiment.Segments`

Given that the Treatment Service only uses the sets of an `ExperimentIndex` to determine a matching experiment, there is no need to store the original copy within `ExperimentIndex.Experiment.Segments`. While this duplication might seem minor and negligible, we have observed instances whereby experiments with a huge number of segmenter values cause a huge increase in memory usage by the Treatment Service due to the duplication of the data stored in memory.

This PR simply removes the values in `ExperimentIndex.Experiment.Segments` once they have been used to initialise the various sets, to reduce the overall memory footprint of the Treatment Service. Additional changes to existing functions are also made to accommodate the removal of that field.