### PR TITLE
Add DB connection configs

### DIFF
--- a/management-service/config/config.go
+++ b/management-service/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/gojek/mlp/api/pkg/instrumentation/newrelic"
 	"github.com/gojek/mlp/api/pkg/instrumentation/sentry"
@@ -40,6 +41,11 @@ type DatabaseConfig struct {
 	Password       string `default:"xp"`
 	Database       string `default:"xp"`
 	MigrationsPath string `default:"file://database/db-migrations"`
+
+	ConnMaxIdleTime time.Duration `default:"0s"`
+	ConnMaxLifetime time.Duration `default:"0s"`
+	MaxIdleConns    int           `default:"0"`
+	MaxOpenConns    int           `default:"0"`
 }
 
 // MLPConfig captures the configuration used to connect to the MLP API server

--- a/management-service/config/config_test.go
+++ b/management-service/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gojek/mlp/api/pkg/instrumentation/newrelic"
 	"github.com/gojek/mlp/api/pkg/instrumentation/sentry"
@@ -11,6 +12,7 @@ import (
 )
 
 func TestDefaultConfigs(t *testing.T) {
+	zeroSecond, _ := time.ParseDuration("0s")
 	emptyInterfaceMap := make(map[string]interface{})
 	emptyStringMap := make(map[string]string)
 	defaultCfg := Config{
@@ -21,12 +23,16 @@ func TestDefaultConfigs(t *testing.T) {
 			URL:     "",
 		},
 		DbConfig: &DatabaseConfig{
-			Host:           "localhost",
-			Port:           5432,
-			User:           "xp",
-			Password:       "xp",
-			Database:       "xp",
-			MigrationsPath: "file://database/db-migrations",
+			Host:            "localhost",
+			Port:            5432,
+			User:            "xp",
+			Password:        "xp",
+			Database:        "xp",
+			MigrationsPath:  "file://database/db-migrations",
+			ConnMaxIdleTime: zeroSecond,
+			ConnMaxLifetime: zeroSecond,
+			MaxIdleConns:    0,
+			MaxOpenConns:    0,
 		},
 		SegmenterConfig: make(map[string]interface{}),
 		MLPConfig: &MLPConfig{
@@ -64,6 +70,8 @@ func TestDefaultConfigs(t *testing.T) {
 // TestLoadConfigFiles verifies that when multiple configs are passed in
 // they are consumed in the correct order
 func TestLoadConfigFiles(t *testing.T) {
+	oneSecond, _ := time.ParseDuration("1s")
+	twoSecond, _ := time.ParseDuration("2s")
 	tests := []struct {
 		name        string
 		configFiles []string
@@ -81,12 +89,16 @@ func TestLoadConfigFiles(t *testing.T) {
 					URL:     "test-authz-server",
 				},
 				DbConfig: &DatabaseConfig{
-					Host:           "localhost",
-					Port:           5432,
-					User:           "admin",
-					Password:       "password",
-					Database:       "xp",
-					MigrationsPath: "file://test-db-migrations",
+					Host:            "localhost",
+					Port:            5432,
+					User:            "admin",
+					Password:        "password",
+					Database:        "xp",
+					MigrationsPath:  "file://test-db-migrations",
+					ConnMaxIdleTime: oneSecond,
+					ConnMaxLifetime: twoSecond,
+					MaxIdleConns:    3,
+					MaxOpenConns:    4,
 				},
 				SegmenterConfig: map[string]interface{}{
 					"s2_ids": map[string]interface{}{

--- a/management-service/services/configuration_service.go
+++ b/management-service/services/configuration_service.go
@@ -14,8 +14,7 @@ type configurationService struct {
 }
 
 func NewConfigurationService(cfg *config.Config) ConfigurationService {
-	var segmenterConfig schema.SegmenterConfig
-	segmenterConfig = cfg.SegmenterConfig
+	var segmenterConfig schema.SegmenterConfig = cfg.SegmenterConfig
 
 	return &configurationService{
 		treatmentServiceConfig: schema.TreatmentServiceConfig{

--- a/management-service/testdata/config1.yaml
+++ b/management-service/testdata/config1.yaml
@@ -12,6 +12,10 @@ DbConfig:
   User: user
   Password: password
   MigrationsPath: file://test-db-migrations
+  ConnMaxIdleTime: 1s
+  ConnMaxLifetime: 2s
+  MaxIdleConns: 3
+  MaxOpenConns: 4
 
 MLPConfig:
   URL: test-mlp-url

--- a/treatment-service/services/experiment_service.go
+++ b/treatment-service/services/experiment_service.go
@@ -61,11 +61,13 @@ func (es *experimentService) GetExperiment(
 		func(matches []*models.ExperimentMatch) []*models.ExperimentMatch {
 			return es.filterByMatchStrength(matches, projectSettings.Segmenters.Names)
 		},
-		// Resolve granularity of Segmenters
+		// Resolve lookup order. At this point, comparing by each segmenter, we should be left with one or more
+		// experiments which are either all exact or all weak. Where there are multiple transformed values returned
+		// by the segmenter, we pick the first transformed value that has a match, to filter the pool of experiments.
 		func(matches []*models.ExperimentMatch) []*models.ExperimentMatch {
 			return es.filterByLookupOrder(matches, requestFilter, projectSettings.Segmenters.Names, segmentersTypeMapping)
 		},
-		// Resolve tiers - at this point, we should ideally only be left with 1 experiment or 2
+		// Resolve tiers. At this point, we should ideally only be left with 1 experiment or 2
 		// (in different tiers), based on the orthogonality rules enforced by the management service.
 		es.filterByTierPriority,
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/caraml-dev/xp/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/caraml-dev/xp/blob/master/CONTRIBUTING.md#unit-tests
3. Make sure documentation is updated for your PR

-->

**What this PR does / why we need it**:

This PR is similar to https://github.com/caraml-dev/turing/pull/312 for Turing. It adds a few DB connection configs to avoid intermittent "broken pipe" errors on outgoing connections to the database. This is done by forcefully closing idle connections to the DB through the following configs (all defaults are 0):

```yaml
  ConnMaxIdleTime: 0s
  ConnMaxLifetime: 0s
  MaxIdleConns: 0
  MaxOpenConns: 0
```

The values can be overridden at deploy time, if needed, through the [apiConfig](https://github.com/caraml-dev/xp/blob/main/infra/charts/management-service/values.yaml#L58) properties. (No explicit chart changes are needed to support this.)
