### PR TITLE
Add logging to plugin fetch treatment method

### DIFF
--- a/plugins/turing/go.mod
+++ b/plugins/turing/go.mod
@@ -19,6 +19,8 @@ require (
 	golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783
 )
 
+require github.com/google/uuid v1.3.0
+
 require (
 	cloud.google.com/go v0.104.0 // indirect
 	cloud.google.com/go/bigquery v1.42.0 // indirect
@@ -61,7 +63,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.2 // indirect

--- a/plugins/turing/go.mod
+++ b/plugins/turing/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/caraml-dev/xp/treatment-service v0.0.0
 	github.com/go-playground/validator/v10 v10.11.1
 	github.com/gojek/mlp v1.5.3
+	github.com/google/uuid v1.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.2 // indirect
 	github.com/stretchr/testify v1.8.0
@@ -18,8 +19,6 @@ require (
 	golang.org/x/net v0.1.0
 	golang.org/x/oauth2 v0.0.0-20221014153046-6fdb5e3db783
 )
-
-require github.com/google/uuid v1.3.0
 
 require (
 	cloud.google.com/go v0.104.0 // indirect


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces the asynchronous logging method to the `GetTreatmentForRequest` method of the XP plugin that generates treatments. This functionality was previously left out from an earlier PR as a mistake, and this PR solely serves to fix that.
