### PR TITLE
Bugfix: Update experiment engine Google client initialisation

### DIFF
--- a/plugins/turing/manager/experiment_manager.go
+++ b/plugins/turing/manager/experiment_manager.go
@@ -10,6 +10,7 @@ import (
 	"github.com/caraml-dev/turing/engines/experiment/log"
 	"github.com/caraml-dev/turing/engines/experiment/manager"
 	inproc "github.com/caraml-dev/turing/engines/experiment/plugin/inproc/manager"
+	"github.com/gojek/mlp/api/pkg/auth"
 
 	xpclient "github.com/caraml-dev/xp/clients/management"
 	"github.com/caraml-dev/xp/common/api/schema"
@@ -17,7 +18,6 @@ import (
 	_config "github.com/caraml-dev/xp/plugins/turing/config"
 	"github.com/caraml-dev/xp/treatment-service/config"
 	"github.com/go-playground/validator/v10"
-	"golang.org/x/oauth2/google"
 )
 
 func init() {
@@ -188,7 +188,7 @@ func NewExperimentManager(configData json.RawMessage) (manager.CustomExperimentM
 	}
 
 	// Create Google Client
-	googleClient, err := google.DefaultClient(context.Background(), googleOAuthScope)
+	googleClient, err := auth.InitGoogleClient(context.Background())
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/turing/manager/experiment_manager.go
+++ b/plugins/turing/manager/experiment_manager.go
@@ -54,9 +54,6 @@ const xpExperimentConfigSchema = `[
   ]
 ]`
 
-// Default scope for the Google Auth token used for the XP APIs
-var googleOAuthScope = "https://www.googleapis.com/auth/userinfo.email"
-
 // experimentManager implements manager.CustomExperimentManager interface
 type experimentManager struct {
 	validate                     *validator.Validate


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is a follow-up/fix to #67, where the Google client initialisation methods have been updated throughout the XP repo. Unfortunately, the experiment manager in the XP plugin has been left out of the previous PR and needs to be updated too.

This PR makes the aforementioned update.

**Which issue(s) this PR fixes**:
Fixes #
