### PR TITLE
Revert PR (#70) - addition of gorm config to update nested fields in the db

### DIFF
--- a/management-service/database/database.go
+++ b/management-service/database/database.go
@@ -29,9 +29,7 @@ func ConnectionString(cfg *config.DatabaseConfig) string {
 func Open(cfg *config.DatabaseConfig) (*gorm.DB, error) {
 	db, err := gorm.Open(pg.Open(ConnectionString(cfg)),
 		&gorm.Config{
-			// This is needed to ensure that any saves to nested fields also update their respective tables
-			FullSaveAssociations: true,
-			Logger:               logger.Default.LogMode(logger.Silent),
+			Logger: logger.Default.LogMode(logger.Silent),
 		})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR reverts the changes introduced in #71, as there is no need to enforce all associations of a Gorm object to be saved. A similar change was first introduced in https://github.com/caraml-dev/turing/pull/331 but it has since been removed in favour of a more precise manner of updating tables that contain nested fields of a Gorm object.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
