### PR TITLE
Set env config to use _ delimiter instead of ::

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Instructions as described in README of https://github.com/caraml-dev/mlp.
 
 #### b. Starting XP
 
-Prior to starting XP, we'll need to ensure correct MLP API is correctly set in the config file, i.e management-service/config/example.yaml, and setting the correct `MLPConfig::URL` value.
+Prior to starting XP, we'll need to ensure correct MLP API is correctly set in the config file, i.e management-service/config/example.yaml, and setting the correct `MLPConfig_URL` value.
 
 ```bash
 # Start Management Service

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -26,9 +26,9 @@ func ParseConfig(spec interface{}, filepaths []string) error {
 	}
 
 	// Load config values from environment variables.
-	// Nested keys in the config is represented by variable name separated by '::'.
-	// For example, DbConfig.Host can be set from environment variable DBCONFIG::HOST.
-	v.SetEnvKeyReplacer(strings.NewReplacer(".", "::"))
+	// Nested keys in the config is represented by variable name separated by '_'.
+	// For example, DbConfig.Host can be set from environment variable DBCONFIG_HOST.
+	v.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	v.AutomaticEnv()
 
 	// Unmarshal config values into the config object.

--- a/common/config/config_test.go
+++ b/common/config/config_test.go
@@ -62,9 +62,9 @@ func TestEnvConfigs(t *testing.T) {
 
 	os.Setenv("HOST", host)
 	os.Setenv("PORT", port)
-	os.Setenv("PUBSUB::PROJECT", pubSubProject)
-	os.Setenv("PUBSUB::TOPICNAME", pubSubTopicName)
-	os.Setenv("SENTRY::URL", sentryUrl)
+	os.Setenv("PUBSUB_PROJECT", pubSubProject)
+	os.Setenv("PUBSUB_TOPICNAME", pubSubTopicName)
+	os.Setenv("SENTRY_URL", sentryUrl)
 
 	cfg := tu.Config{}
 	var filePaths []string

--- a/tests/e2e/fixtures/services.py
+++ b/tests/e2e/fixtures/services.py
@@ -115,7 +115,7 @@ def _start_management_service(
     pubsub_topic = pubsub_config.get("TopicName", "xp-update")
     create_pubsub_topic(pubsub_project, pubsub_topic)
 
-    os.environ["MLPCONFIG::URL"] = mlp_service_url
+    os.environ["MLPCONFIG_URL"] = mlp_service_url
 
     process = _start_binary(
         bin_path,

--- a/treatment-service/integration-test/fetch_treatment_it_test.go
+++ b/treatment-service/integration-test/fetch_treatment_it_test.go
@@ -307,7 +307,7 @@ func setupManagementServiceClient() (*management.ClientWithResponses, *httptest.
 }
 
 func setupTreatmentService(managementServiceServerURL string) (chan bool, *server.Server) {
-	os.Setenv("MANAGEMENTSERVICE::URL", managementServiceServerURL)
+	os.Setenv("MANAGEMENTSERVICE_URL", managementServiceServerURL)
 	treatmentServer, err := server.NewServer([]string{"test.yaml"})
 	if err != nil {
 		log.Fatalf("fail to instantiate treatment server: %s", err.Error())
@@ -344,8 +344,8 @@ func (suite *TreatmentServiceTestSuite) SetupSuite() {
 	ctx := context.Background()
 	os.Setenv("PORT", strconv.Itoa(TreatmentServerPort))
 	os.Setenv("PROJECTIDS", "1,2,3,4,5")
-	os.Setenv("PUBSUB::PROJECT", PubSubProject)
-	os.Setenv("PUBSUB::TOPICNAME", TopicName)
+	os.Setenv("PUBSUB_PROJECT", PubSubProject)
+	os.Setenv("PUBSUB_TOPICNAME", TopicName)
 
 	emulator, pubsubClient, err := testutils.StartPubSubEmulator(context.Background(), PubSubProject)
 	if err != nil {
@@ -379,7 +379,7 @@ func (suite *TreatmentServiceTestSuite) SetupSuite() {
 		panic(err)
 	}
 	suite.kafka = kafka
-	os.Setenv("ASSIGNEDTREATMENTLOGGER::KAFKACONFIG::BROKERS", "localhost:9092")
+	os.Setenv("ASSIGNEDTREATMENTLOGGER_KAFKACONFIG_BROKERS", "localhost:9092")
 
 	c, treatmentServer := setupTreatmentService(suite.managementServiceServer.URL)
 	waitForServerToListen := func() bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/caraml-dev/xp/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/caraml-dev/xp/blob/master/CONTRIBUTING.md#unit-tests
3. Make sure documentation is updated for your PR

-->

**What this PR does / why we need it**:
* This PR replaces the `::` delimiter with `_` so `DBCONFIG::PASSWORD` becomes `DBCONFIG_PASSWORD`
* This is to allow the setting of environment variables in `env` field in K8s PodSpec, which opens up the option to set env vars using ConfigMaps or Secrets
* Currently caraml-dev/helm-charts https://github.com/caraml-dev/helm-charts/actions/runs/4943497133/jobs/8838050166?pr=243 is failing because of the use of this delimiter

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
nil

cc @mbruner 