### PR TITLE
fix(ui): Fix yup validation bug

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -8,7 +8,7 @@
   "//": "[@sentry/browser] pinned to 7.118.0 because craco/module federation has issues resolving this dependency; see",
   "//": "https://github.com/caraml-dev/turing/pull/384#discussion_r1666418144 for more details",
   "dependencies": {
-    "@caraml-dev/ui-lib": "^1.13.0-build.3-a234b6b",
+    "@caraml-dev/ui-lib": "^1.13.0-build.4-09c363a",
     "@elastic/datemath": "^5.0.3",
     "@elastic/eui": "88.2.0",
     "@emotion/css": "^11.11.2",

--- a/ui/src/experiments/components/form/validation/schema.js
+++ b/ui/src/experiments/components/form/validation/schema.js
@@ -138,10 +138,10 @@ const schema = [
       .max(64, "Name should be between 4 and 64 characters")
       .matches(nameRegex, nameRegexDescription),
     type: yup
-      .mixed()
+      .string()
       .required("Experiment Type should be selected")
       .oneOf(experimentTypeValues, "Valid Experiment Type should be selected"),
-    interval: yup.mixed().when("type", (type, schema) => {
+    interval: yup.string().when("type", ([type], schema) => {
       return type === "Switchback"
         ? yup
           .number()
@@ -151,11 +151,11 @@ const schema = [
         : schema;
     }),
     tier: yup
-      .mixed()
+      .string()
       .required("Experiment Tier should be selected")
       .oneOf(experimentTierValues, "Valid Experiment Tier should be selected"),
     status: yup
-      .mixed()
+      .string()
       .required("Experiment Status should be selected")
       .oneOf(
         experimentStatusValues,
@@ -165,7 +165,7 @@ const schema = [
     end_time: yup
       .date()
       .required("End Time is required")
-      .when("start_time", (startTime, schema) => {
+      .when("start_time", ([startTime], schema) => {
         return startTime ? schema.min(startTime) : schema;
       }),
   }),
@@ -176,7 +176,7 @@ const schema = [
     treatments: yup
       .array()
       .of(treatmentSchema)
-      .when("type", (type, schema) => {
+      .when("type", ([type], schema) => {
         switch (type) {
           case "A/B":
             return schema

--- a/ui/src/experiments/list/search/SearchExperimentsPanel.js
+++ b/ui/src/experiments/list/search/SearchExperimentsPanel.js
@@ -6,16 +6,14 @@ import { SegmenterContextProvider } from "providers/segmenter/context";
 
 import SearchExperimentsFilters from "./SearchExperimentsFilters";
 
-import "./SearchExperimentsPanel.scss";
-
 const SearchExperimentsPanel = ({ onChange, onClose, projectId }) => {
   return (
     <SegmenterContextProvider projectId={projectId}>
       <EuiFlyout
         id="experiments-search-panel"
-        className="euiFlyout--searchPanel"
         side="left"
         onClose={onClose}
+        size={"s"}
         maxWidth={true}
         hideCloseButton={true}
         paddingSize="m"

--- a/ui/src/experiments/list/search/SearchExperimentsPanel.scss
+++ b/ui/src/experiments/list/search/SearchExperimentsPanel.scss
@@ -1,6 +1,0 @@
-// Required for setting a specific flyout width that is smaller than the default EUI flyout width (medium); overwrites
-// the min-width that corresponds to the default EUI flyout width
-.euiFlyout--searchPanel{
-  width: 313px;
-  min-width: unset;
-}

--- a/ui/src/experiments/list/search/validation/schema.js
+++ b/ui/src/experiments/list/search/validation/schema.js
@@ -4,7 +4,7 @@ const schema = yup.lazy((obj) => {
   if (!!obj.start_time || !!obj.end_time) {
     return yup.object().shape({
       start_time: yup.date().required("End time is set, Start time required"),
-      end_time: yup.mixed().when("start_time", (startTime, schema) => {
+      end_time: yup.mixed().when("start_time", ([startTime], schema) => {
         return !!startTime
           ? yup
               .date()

--- a/ui/src/segments/components/form/validation/schema.js
+++ b/ui/src/segments/components/form/validation/schema.js
@@ -8,7 +8,7 @@ export const segmentConfigSchema = yup.lazy((obj) =>
       return {
         ...acc,
         [key]: yup.mixed()
-          .when("$segmenterTypes", (segmenterTypes) => {
+          .when("$segmenterTypes", ([segmenterTypes], _) => {
             switch ((segmenterTypes[key] || "").toUpperCase()) {
               case "BOOL":
                 return yup.array(
@@ -43,7 +43,7 @@ export const segmentConfigSchema = yup.lazy((obj) =>
           })
           .when(
             "$requiredSegmenterNames",
-            (requiredSegmenterNames, schema) => {
+            ([requiredSegmenterNames], schema) => {
               if (requiredSegmenterNames.includes(key)) {
                 return schema
                   .required(`Segmenter ${key} is required`)

--- a/ui/src/settings/segmenters/components/form/validation/schema.js
+++ b/ui/src/settings/segmenters/components/form/validation/schema.js
@@ -74,7 +74,7 @@ const schema = [
       .max(64, "Name should be between 4 and 64 characters")
       .matches(nameRegex, nameRegexDescription),
     type: yup
-      .mixed()
+      .string()
       .required("Segmenter Value Type should be selected")
       .oneOf(
         typeOptionsValues,

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1913,10 +1913,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@caraml-dev/ui-lib@^1.13.0-build.3-a234b6b":
-  version "1.13.0-build.3-a234b6b"
-  resolved "https://registry.yarnpkg.com/@caraml-dev/ui-lib/-/ui-lib-1.13.0-build.3-a234b6b.tgz#f24d09d00c77f1288953da8f06893970cdeeda13"
-  integrity sha512-aiOWz2QNKJ3uK8No8r9FAfHHQNHe9cvSV5Bgznj7PRaTMpJbfDDSY8U+z+B60SjdtZ7qeeTiC14cEpmv/Ot07Q==
+"@caraml-dev/ui-lib@^1.13.0-build.4-09c363a":
+  version "1.13.0-build.4-09c363a"
+  resolved "https://registry.yarnpkg.com/@caraml-dev/ui-lib/-/ui-lib-1.13.0-build.4-09c363a.tgz#c80987fa5c7989450095d354acf51a023ca94e15"
+  integrity sha512-kqb/5koS2IQtdLJIh5tk+t30ZX2GvvQO7kAuE9oKXKlwBPr83Q+lvLxcvSg+rxILYxjOUeNn2izoej0ZGMDoRg==
   dependencies:
     "@react-oauth/google" "0.12.1"
     classnames "^2.5.1"


### PR DESCRIPTION
**What this PR does / why we need it**:
Similar to https://github.com/caraml-dev/turing/pull/387, this PR to fixes broken validation schemas caused by the upgrade of the `yup` package in PR #591 - these changes can largely be grouped into the following:

- When using the same `Schema.when` function but passing a function directly as an argument instead of the builder object, the signature of the expected function has also been updated from `(value, schema)=> Schema): Schema` to `(values: any[], schema) => Schema): Schema`.

  Existing schemas that do not follow this convention now have been updated to reflect the new expected array:

  Example:
  ```javascript
  // before
  some_field: yup.string().when("some_other_field", (some_other_field, schema) =>
    some_other_field ? yup.string().required("this is needed") : schema
  ),

  // after
  some_field: yup.string().when("some_other_field", ([some_other_field], schema) =>
    some_other_field ? yup.string().required("this is needed") : schema
  ),
  ```
- The `mixed` schema has been severely nerfed and is now no longer the base class for all the other schemas, and as such no longer supports a lot of the other functions that we were previously calling. Schemas that have fields which use the `mixed` schema have been updated to use a schema (e.g. `string`) corresponding to its expected primitive data type wherever possible (where we know that only a specific type is expected).

This PR also bumps up the version of the `caraml-dev/ui-lib` library to the latest version and removes custom css styles for the experiments search sidebar which no longer work.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
