### PR TITLE
fix(ui): Update broken yup-ast schema

### DIFF
--- a/plugins/turing/manager/experiment_manager.go
+++ b/plugins/turing/manager/experiment_manager.go
@@ -43,7 +43,7 @@ const xpExperimentConfigSchema = `[
       "variables": [["yup.array"], ["yup.of", [["yup.object"], ["yup.shape",
         {
           "name": [["yup.string"], ["yup.required"]],
-          "field": ["yup.string"],
+          "field": [["yup.string"]],
           "field_source": [["yup.string"],
             ["yup.required"],
             ["yup.oneOf", ["none", "header", "payload"], "One of the supported field sources should be selected"]]


### PR DESCRIPTION
**What this PR does / why we need it**:
In https://github.com/caraml-dev/turing/pull/390, the `yup-ast` package has been updated to use a much newer and updated alternative. However, after fixing that problem, it was found that the existing experiment engine `yup-ast` schema specified in [XP](https://github.com/caraml-dev/xp/blob/cb06edaaf409077b5abf7fed0b803984b6decf7e/plugins/turing/manager/experiment_manager.go#L38C1-L38C36) isn't working, i.e. the validation schema is invalid and `yup` allows the entire config to pass even if it fails certain fields in the validation schema.

Apparently what's needed to be fix is to simply add additional square brackets when defining a list of validation checks in the schema specified for a specific field (only when using the `yup.shape` check). I've tested these changes locally.

I can't tell if this wasn't working in the past or if the schema change is only expected by the newer `@demvsystems/yup-ast` package so I'm opening both PRs to fix this issue once and for all. (Yes I know that's a TODO to clean this part up but I'm ignoring it for now to get this fix released as soon as possible since it's blocking some users from deploying their Turing routers).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
