### PR TITLE
fix(ui): Fix segmenter yup validation schema

### DIFF
--- a/ui/src/settings/components/form/validation/schema.js
+++ b/ui/src/settings/components/form/validation/schema.js
@@ -71,7 +71,7 @@ const schema = [
       names: yup
         .array()
         .test("segmenter-dependencies", validateSegmenterSelection),
-      variables: yup.object().when("names", (names, schema) => {
+      variables: yup.object().when("names", ([names], schema) => {
         const shape = names.reduce((acc, name) => {
           acc[name] = yup
             .array()


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces an additional fix to the yup validation schema, as a follow up from #80. In particular, the fix in this PR addresses this change:

- When using the same `Schema.when` function but passing a function directly as an argument instead of the builder object, the signature of the expected function has also been updated from `(value, schema)=> Schema): Schema` to `(values: any[], schema) => Schema): Schema`.

  Existing schemas that do not follow this convention now have been updated to reflect the new expected array:

  Example:
  ```javascript
  // before
  some_field: yup.string().when("some_other_field", (some_other_field, schema) =>
    some_other_field ? yup.string().required("this is needed") : schema
  ),

  // after
  some_field: yup.string().when("some_other_field", ([some_other_field], schema) =>
    some_other_field ? yup.string().required("this is needed") : schema
  ),

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
