### PR TITLE
chore(docker): Update base docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine as api-builder
+FROM golang:1.21-alpine as api-builder
 ARG API_BIN_NAME=xp-management
 
 ENV GO111MODULE=on \

--- a/plugins/turing/Dockerfile
+++ b/plugins/turing/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine as plugin-builder
+FROM golang:1.21-alpine as plugin-builder
 
 RUN apk update && apk add git make bash unzip libtool gcc musl-dev ca-certificates dumb-init tzdata
 

--- a/treatment-service/Dockerfile
+++ b/treatment-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine as api-builder
+FROM golang:1.21-alpine as api-builder
 ARG API_BIN_NAME=xp-treatment
 
 RUN apk update && apk add musl-dev gcc


### PR DESCRIPTION
**What this PR does / why we need it**:
With the upgrade of Go from 1.18 to 1.21 in all of XP's components, we need to update the docker base image used to build them. This PR updates the version of Go in these base images from 1.18 to 1.21.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
