### PR TITLE
fix(ui): Add helper function to cast string to array before yup validation

### DIFF
--- a/ui/src/settings/segmenters/components/form/validation/schema.js
+++ b/ui/src/settings/segmenters/components/form/validation/schema.js
@@ -55,30 +55,28 @@ const optionsSchema = yup
     }
   );
 
-const validateArrayString = (arraySchema, arrayName) => {
-  return yup
-    .string()
-    .test(
-      `${arrayName} valid JSON array`,
-      `${arrayName} must be a valid JSON array`,
-      (array) => {
-        if (array !== "") {
-          try {
-            var parsedArray = JSON.parse(array);
-            if (typeof parsedArray != "array" && !Array.isArray(parsedArray)) {
-              return false;
-            }
-            return arraySchema
-              .validateSync(parsedArray);
-          } catch (e) {
+const validateArrayString = (arraySchema, arrayName) => yup
+  .string()
+  .test(
+    `${arrayName} valid JSON array`,
+    `${arrayName} must be a valid JSON array`,
+    (array) => {
+      if (array !== "") {
+        try {
+          var parsedArray = JSON.parse(array);
+          if (typeof parsedArray != "array" && !Array.isArray(parsedArray)) {
             return false;
           }
-          
+          return arraySchema
+            .validateSync(parsedArray);
+        } catch (e) {
+          return false;
         }
-        return true;
+
       }
-    )
-}
+      return true;
+    }
+  );
 
 const constraintSchema = yup.object().shape({
   pre_requisites: validateArrayString(yup.array(preRequisiteSchema), "Pre-requisites")

--- a/ui/src/settings/segmenters/components/form/validation/schema.js
+++ b/ui/src/settings/segmenters/components/form/validation/schema.js
@@ -72,7 +72,6 @@ const validateArrayString = (arraySchema, arrayName) => yup
         } catch (e) {
           return false;
         }
-
       }
       return true;
     }

--- a/ui/src/settings/segmenters/components/form/validation/schema.js
+++ b/ui/src/settings/segmenters/components/form/validation/schema.js
@@ -64,7 +64,7 @@ const validateArrayString = (arraySchema, arrayName) => yup
       if (array !== "") {
         try {
           var parsedArray = JSON.parse(array);
-          if (typeof parsedArray != "array" && !Array.isArray(parsedArray)) {
+          if (typeof parsedArray != "object" || !Array.isArray(parsedArray)) {
             return false;
           }
           return arraySchema

--- a/ui/src/settings/segmenters/components/form/validation/schema.js
+++ b/ui/src/settings/segmenters/components/form/validation/schema.js
@@ -55,13 +55,37 @@ const optionsSchema = yup
     }
   );
 
+const validateArrayString = (arraySchema, arrayName) => {
+  return yup
+    .string()
+    .test(
+      `${arrayName} valid JSON array`,
+      `${arrayName} must be a valid JSON array`,
+      (array) => {
+        if (array !== "") {
+          try {
+            var parsedArray = JSON.parse(array);
+            if (typeof parsedArray != "array" && !Array.isArray(parsedArray)) {
+              return false;
+            }
+            return arraySchema
+              .validateSync(parsedArray);
+          } catch (e) {
+            return false;
+          }
+          
+        }
+        return true;
+      }
+    )
+}
+
 const constraintSchema = yup.object().shape({
-  pre_requisites: yup
-    .array(preRequisiteSchema)
+  pre_requisites: validateArrayString(yup.array(preRequisiteSchema), "Pre-requisites")
     .typeError(
       "Constraint pre-requisites must be a valid array of pre-requisite objects"
     ),
-  allowed_values: segmenterValuesSchema,
+  allowed_values: validateArrayString(segmenterValuesSchema, "Allowed values"),
   options: optionsSchema,
 });
 


### PR DESCRIPTION
**What this PR does / why we need it**:
It seems like after updating yup/elastic UI packages, array values in the `EuiTextArea` are expressed as a JSON literal, e.g. `"[\"new\"]"` and these values no longer get automatically parsed into a JSON array at the yup validation stage. As a result, all the `.array()` validations that were performed no longer work and fail (because they report a string being present instead). The screenshot attached shows how the validation reports an error even though nothing is wrong with the input in the text fields.

An additional step is thus introduced to manually parse the literal input into a JSON array (failing the validation check if it isn't), and to validate the parsed array with respect to the original schema. 

![Screenshot 2024-08-12 at 13 41 11](https://github.com/user-attachments/assets/fbaaea30-1522-4cb1-bf2e-1b33f5ee0279)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
