### PR TITLE
fix(xp-treatment): Add field tags to poller configs and make XP plugin pass poller configs

### DIFF
--- a/plugins/turing/config/config.go
+++ b/plugins/turing/config/config.go
@@ -46,14 +46,15 @@ type TreatmentServicePluginConfig struct {
 	Port                 int `json:"port" default:"8080"`
 	PubSubTimeoutSeconds int `json:"pub_sub_timeout_seconds" validate:"required"`
 
-	AssignedTreatmentLogger config.AssignedTreatmentLoggerConfig `json:"assigned_treatment_logger"`
-	DebugConfig             config.DebugConfig                   `json:"debug_config"`
-	DeploymentConfig        config.DeploymentConfig              `json:"deployment_config"`
-	ManagementService       config.ManagementServiceConfig       `json:"management_service"`
-	MonitoringConfig        config.Monitoring                    `json:"monitoring_config"`
-	SwaggerConfig           config.SwaggerConfig                 `json:"swagger_config"`
-	NewRelicConfig          newrelic.Config                      `json:"new_relic_config"`
-	SentryConfig            sentry.Config                        `json:"sentry_config"`
+	AssignedTreatmentLogger       config.AssignedTreatmentLoggerConfig `json:"assigned_treatment_logger"`
+	DebugConfig                   config.DebugConfig                   `json:"debug_config"`
+	DeploymentConfig              config.DeploymentConfig              `json:"deployment_config"`
+	ManagementService             config.ManagementServiceConfig       `json:"management_service"`
+	MonitoringConfig              config.Monitoring                    `json:"monitoring_config"`
+	SwaggerConfig                 config.SwaggerConfig                 `json:"swagger_config"`
+	NewRelicConfig                newrelic.Config                      `json:"new_relic_config"`
+	SentryConfig                  sentry.Config                        `json:"sentry_config"`
+	ManagementServicePollerConfig config.ManagementServicePollerConfig `json:"management_service_poller_config"`
 }
 
 type Variable struct {

--- a/plugins/turing/manager/experiment_manager.go
+++ b/plugins/turing/manager/experiment_manager.go
@@ -142,17 +142,18 @@ func (em *experimentManager) MakeTreatmentServicePluginConfig(
 	projectID int,
 ) (*config.Config, error) {
 	pluginConfig := &config.Config{
-		Port:                    em.TreatmentServicePluginConfig.Port,
-		ProjectIds:              []string{strconv.Itoa(projectID)},
-		AssignedTreatmentLogger: em.TreatmentServicePluginConfig.AssignedTreatmentLogger,
-		DebugConfig:             em.TreatmentServicePluginConfig.DebugConfig,
-		DeploymentConfig:        em.TreatmentServicePluginConfig.DeploymentConfig,
-		ManagementService:       em.TreatmentServicePluginConfig.ManagementService,
-		MonitoringConfig:        em.TreatmentServicePluginConfig.MonitoringConfig,
-		SwaggerConfig:           em.TreatmentServicePluginConfig.SwaggerConfig,
-		NewRelicConfig:          em.TreatmentServicePluginConfig.NewRelicConfig,
-		SentryConfig:            em.TreatmentServicePluginConfig.SentryConfig,
-		SegmenterConfig:         *treatmentServiceConfig.SegmenterConfig,
+		Port:                          em.TreatmentServicePluginConfig.Port,
+		ProjectIds:                    []string{strconv.Itoa(projectID)},
+		AssignedTreatmentLogger:       em.TreatmentServicePluginConfig.AssignedTreatmentLogger,
+		DebugConfig:                   em.TreatmentServicePluginConfig.DebugConfig,
+		DeploymentConfig:              em.TreatmentServicePluginConfig.DeploymentConfig,
+		ManagementService:             em.TreatmentServicePluginConfig.ManagementService,
+		MonitoringConfig:              em.TreatmentServicePluginConfig.MonitoringConfig,
+		SwaggerConfig:                 em.TreatmentServicePluginConfig.SwaggerConfig,
+		NewRelicConfig:                em.TreatmentServicePluginConfig.NewRelicConfig,
+		SentryConfig:                  em.TreatmentServicePluginConfig.SentryConfig,
+		SegmenterConfig:               *treatmentServiceConfig.SegmenterConfig,
+		ManagementServicePollerConfig: em.TreatmentServicePluginConfig.ManagementServicePollerConfig,
 	}
 	messageQueueKind := *treatmentServiceConfig.MessageQueueConfig.Kind
 	switch messageQueueKind {

--- a/treatment-service/config/config.go
+++ b/treatment-service/config/config.go
@@ -96,8 +96,8 @@ type ManagementServiceConfig struct {
 }
 
 type ManagementServicePollerConfig struct {
-	Enabled      bool          `default:"false"`
-	PollInterval time.Duration `default:"30s"`
+	Enabled      bool          `json:"enabled" default:"false"`
+	PollInterval time.Duration `json:"poll_interval" default:"30s"`
 }
 
 func (c *Config) GetProjectIds() []models.ProjectId {


### PR DESCRIPTION
**What this PR does / why we need it**:
In PR #88, a new XP Management Service poller was introduced to the XP Treatment Service. Unfortunately the configs for this feature lacked the necessary field tags (`json`) to parse configs from the config file into actual values in Go. 

In addition, the XP plugin wasn't modified to pass the poller configs from the plugin manager to the plugin runner, which results in the plugin runner not being able to use the new poller service that had been introduced in the previous PR.

This PR adds these missing tags and fixes the XP plugin to pass those new poller configs to be passed to the plugin runner.

cc @rautelaanirudh 

**Which issue(s) this PR fixes**:
- Fixes inability to read poller configs from the config file
- Fixes inability of the plugin runner to use the poller service
