### PR TITLE
fix(xp-treatment,plugin): Fix treatment service and plugin's method of initiating management service client

### DIFF
--- a/treatment-service/appcontext/appcontext.go
+++ b/treatment-service/appcontext/appcontext.go
@@ -32,7 +32,6 @@ func NewAppContext(cfg *config.Config) (*AppContext, error) {
 	localStorage, err := models.NewLocalStorage(
 		cfg.GetProjectIds(),
 		cfg.ManagementService.URL,
-		cfg.ManagementService.AuthorizationEnabled,
 		cfg.DeploymentConfig.GoogleApplicationCredentialsEnvVar,
 	)
 	if err != nil {

--- a/treatment-service/appcontext/appcontext_test.go
+++ b/treatment-service/appcontext/appcontext_test.go
@@ -78,7 +78,6 @@ func TestContext(t *testing.T) {
 	localStorage, err := models.NewLocalStorage(
 		testConfig.GetProjectIds(),
 		testConfig.ManagementService.URL,
-		testConfig.ManagementService.AuthorizationEnabled,
 		"",
 	)
 	if err != nil {

--- a/treatment-service/integration-test/fetch_treatment_it_test.go
+++ b/treatment-service/integration-test/fetch_treatment_it_test.go
@@ -807,7 +807,7 @@ func (suite *TreatmentServiceTestSuite) TestAllFiltersSwitchback() {
 }
 
 func (suite *TreatmentServiceTestSuite) TestLocalStorage() {
-	storage, err := models.NewLocalStorage([]models.ProjectId{1}, suite.managementServiceServer.URL, false, "")
+	storage, err := models.NewLocalStorage([]models.ProjectId{1}, suite.managementServiceServer.URL, "")
 	suite.Require().NoError(err)
 	suite.Require().NotEmpty(storage)
 

--- a/treatment-service/models/storage.go
+++ b/treatment-service/models/storage.go
@@ -561,7 +561,6 @@ func (s *LocalStorage) getAllProjects() ([]*pubsub.ProjectSettings, error) {
 func NewLocalStorage(
 	projectIds []ProjectId,
 	xpServer string,
-	authzEnabled bool,
 	googleApplicationCredentialsEnvVar string,
 ) (*LocalStorage, error) {
 	// Set up Request Modifiers

--- a/treatment-service/models/storage.go
+++ b/treatment-service/models/storage.go
@@ -566,26 +566,29 @@ func NewLocalStorage(
 ) (*LocalStorage, error) {
 	// Set up Request Modifiers
 	clientOptions := []managementClient.ClientOption{}
-	if authzEnabled {
-		var googleClient *http.Client
-		var err error
-		// Init Google client for Authz. When using a non-empty googleApplicationCredentialsEnvVar that contains a file
-		// path to a credentials file, the credentials file MUST contain a Google SERVICE ACCOUNT for authentication to
-		// work correctly
-		if filepath := os.Getenv(googleApplicationCredentialsEnvVar); filepath != "" {
-			googleClient, err = auth.InitGoogleClientFromCredentialsFile(context.Background(), filepath)
-		} else {
-			googleClient, err = auth.InitGoogleClient(context.Background())
-		}
-		if err != nil {
-			return nil, err
-		}
 
-		clientOptions = append(
-			clientOptions,
-			managementClient.WithHTTPClient(googleClient),
-		)
+	httpClient := http.DefaultClient
+	var googleClient *http.Client
+	var err error
+	// Init Google client for Authz. When using a non-empty googleApplicationCredentialsEnvVar that contains a file
+	// path to a credentials file, the credentials file MUST contain a Google SERVICE ACCOUNT for authentication to
+	// work correctly
+	if filepath := os.Getenv(googleApplicationCredentialsEnvVar); filepath != "" {
+		googleClient, err = auth.InitGoogleClientFromCredentialsFile(context.Background(), filepath)
+	} else {
+		googleClient, err = auth.InitGoogleClient(context.Background())
 	}
+
+	if err == nil {
+		httpClient = googleClient
+	} else {
+		log.Println("Google default credential not found. Fallback to HTTP default client")
+	}
+
+	clientOptions = append(
+		clientOptions,
+		managementClient.WithHTTPClient(httpClient),
+	)
 	xpClient, err := managementClient.NewClientWithResponses(xpServer, clientOptions...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:
In the XP plugin manager, the Management Service client is always initialised with a Google client, meaning that it always expects a Google service account's or user's credentials to always be present for authenticating all outgoing requests from the plugin. Failing to configure either of these will cause the plugin manager to fail at start up since the Google client cannot be initialised properly. This PR removes the need of any Google credentials and instead allows the Management Service client to be started up with a default HTTP client.

In a somewhat similar fashion, the XP Treatment Service also attempts to initialise a Google client with the aforementioned credentials (and fails at start up if they aren't configured) if the `ManagementService.AuthorizationEnabled` config is set to `true`. This is problematic in two ways, the first is similar to what is described above - if there aren't any Google credentials configured, the application would simply fail at start up, and the second is with the inconsistent naming/usage of the `AuthorizationEnabled` field. Across all the CaraML products (including the XP Management Service), **authorization** is handled by a separate [enforcer layer ](https://github.com/caraml-dev/xp/blob/649e5f6e25ff5d4f651945a27ed5c5a149ffe08d/management-service/server/server.go#L83) that determines the permissions associated with a certain user/request but in the XP Treatment Service, this is taken to mean **authentication** instead, since the initialisation of the Google client only serves to append identity-specific headers to identify the sender of all outgoing requests. This PR thus also refactors away the `ManagementService.AuthorizationEnabled` field and instead just attempts to initialise a Google client but if that fails, uses a regular default HTTP client instead.

**Which issue(s) this PR fixes**:
Fixes #
