### PR TITLE
feat: improve locking: lock only after fetch completed

### DIFF
--- a/treatment-service/models/storage.go
+++ b/treatment-service/models/storage.go
@@ -625,7 +625,10 @@ func NewLocalStorage(
 	return &s, err
 }
 
-func (s *LocalStorage) fetchExperiments(subscribedProjectSettings []*pubsub.ProjectSettings, projectSegmenters map[ProjectId]map[string]schema.SegmenterType) (map[ProjectId][]*ExperimentIndex, error) {
+func (s *LocalStorage) fetchExperiments(
+	subscribedProjectSettings []*pubsub.ProjectSettings,
+	projectSegmenters map[ProjectId]map[string]schema.SegmenterType,
+) (map[ProjectId][]*ExperimentIndex, error) {
 	log.Println("retrieving project experiments...")
 	index := make(map[ProjectId][]*ExperimentIndex)
 	for _, projectSettings := range subscribedProjectSettings {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Ensure that your code follows our code conventions: https://github.com/caraml-dev/xp/blob/master/CONTRIBUTING.md#code-style--linting
2. Run unit tests and ensure that they are passing: https://github.com/caraml-dev/xp/blob/master/CONTRIBUTING.md#unit-tests
3. Make sure documentation is updated for your PR

-->

**What this PR does / why we need it**: 

When pubsub disabled and poll enabled, every time poller runs XP treatment service tries to acquire write lock and the treatment service refreshes the local storage by doing multiple calls to management service and update the data/maps.

This causes other part that use RLock to be blocked until all the calls and update are done. 

This MR moved the write lock to after all the calls are completed, this reduces duration of RLock being blocked

