### PR TITLE
fix(treatment-service): Add pubsub message ordering flag

### DIFF
--- a/common/testutils/pubsub.go
+++ b/common/testutils/pubsub.go
@@ -82,7 +82,7 @@ func CreateSubscriptions(client *pubsub.Client, ctx context.Context, topicNames 
 		topic := client.Topic(topicName)
 		subscription, err := client.CreateSubscription(ctx,
 			subscriptionId,
-			pubsub.SubscriptionConfig{Topic: topic, ExpirationPolicy: time.Hour * 24})
+			pubsub.SubscriptionConfig{Topic: topic, ExpirationPolicy: time.Hour * 24, EnableMessageOrdering: true})
 		if err != nil {
 			return nil, err
 		}

--- a/treatment-service/services/messagequeue/pubsub_message_queue_service.go
+++ b/treatment-service/services/messagequeue/pubsub_message_queue_service.go
@@ -35,8 +35,9 @@ func newSubscriptionId(topic string) string {
 func newPubsubSubscription(ctx context.Context, client *pubsub.Client, topic string) (*pubsub.Subscription, error) {
 	return client.CreateSubscription(
 		ctx, newSubscriptionId(topic), pubsub.SubscriptionConfig{
-			Topic:            client.Topic(topic),
-			ExpirationPolicy: time.Hour * 24,
+			Topic:                 client.Topic(topic),
+			ExpirationPolicy:      time.Hour * 24,
+			EnableMessageOrdering: true,
 		},
 	)
 }

--- a/treatment-service/testhelper/mockmanagement/server/server_test.go
+++ b/treatment-service/testhelper/mockmanagement/server/server_test.go
@@ -182,8 +182,9 @@ func (suite *ManagementServiceTestSuite) SetupTest() {
 	topic := suite.pubsubClient.Topic(TOPIC)
 	subscriptionId := "sub-" + uuid.NewString()
 	subscription, err := suite.pubsubClient.CreateSubscription(suite.ctx, subscriptionId, pubsub.SubscriptionConfig{
-		Topic:            topic,
-		ExpirationPolicy: time.Hour * 24,
+		Topic:                 topic,
+		ExpirationPolicy:      time.Hour * 24,
+		EnableMessageOrdering: true,
 	})
 	if err != nil {
 		suite.FailNow("fail to instantiate client", err.Error())


### PR DESCRIPTION
**What this PR does / why we need it**:
Message ordering is not turned on for PubSub subscriptions created by the Treatment Service (and by extension the XP plugin), which means that messages received are not guaranteed to be in order. This poses a problem when there is a high volume of messages sent by the Management Service in a short span of time, as the order of messages received is important since these messages directly impact how the correct treatment is assigned to each request (e.g. an experiment is repeatedly turned on and off over a short period of time). 

This PR thus turns on message ordering all subscriptions created to ensure that all instances of the Treatment Service/plugin   are consistent in serving the same treatment to each request by maintaining strict message ordering.

See for more details: https://cloud.google.com/pubsub/docs/ordering#go

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
